### PR TITLE
Vector Integrand Tests

### DIFF
--- a/src/Quadrature.jl
+++ b/src/Quadrature.jl
@@ -203,7 +203,7 @@ function __init__()
              else
                  if prob.batch == 0
                      if isinplace(prob)
-                         dx = similar(a)
+                         # dx = similar(a)
                          f = (x,dx) -> (prob.f(dx,x,prob.p); dx)
                      else
                          f = (x,dx) -> (dx .= prob.f(x,prob.p))

--- a/src/Quadrature.jl
+++ b/src/Quadrature.jl
@@ -140,13 +140,18 @@ function __init__()
                         val = prob.f(prob.lb,prob.p) isa Number ? _val : [_val]
                     else
                         if alg isa CubatureJLh
-                            val,err = Cubature.hcubature(f, prob.lb, prob.ub;
+                            _val,err = Cubature.hcubature(f, prob.lb, prob.ub;
                                                          reltol=reltol, abstol=abstol,
                                                          maxevals=maxiters)
                         else
-                            val,err = Cubature.pcubature(f, prob.lb, prob.ub;
+                            _val,err = Cubature.pcubature(f, prob.lb, prob.ub;
                                                          reltol=reltol, abstol=abstol,
                                                          maxevals=maxiters)
+                        end
+                        if isinplace(prob)
+                            val = _val
+                        else
+                            val = prob.f(prob.lb,prob.p) isa Number ? _val : [_val]
                         end
                      end
                 else

--- a/src/Quadrature.jl
+++ b/src/Quadrature.jl
@@ -336,8 +336,19 @@ function __init__()
                           dx .*= prod((y)->y[1]-y[2],zip(ub,lb))
                       end
                   else
-                      f = function (x,dx)
-                          dx .= prob.f(scale_x(ub,lb,x),p)' .* prod((y)->y[1]-y[2],zip(ub,lb))
+                      if prob.f([prob.lb prob.ub], prob.p) isa Vector
+                          f = function (x,dx)
+                              # @show size(x)
+                              # @show size(dx)
+                              # @show size(scale_x(ub,lb,x))
+                              # @show size(prob.f(scale_x(ub,lb,x),p)')
+                              # @show size(prod((y)->y[1]-y[2],zip(ub,lb)))
+                              dx .= prob.f(scale_x(ub,lb,x),p)' .* prod((y)->y[1]-y[2],zip(ub,lb))
+                          end
+                      else
+                          f = function (x,dx)
+                              dx .= prob.f(scale_x(ub,lb,x),p) .* prod((y)->y[1]-y[2],zip(ub,lb))
+                          end
                       end
                   end
               end

--- a/src/Quadrature.jl
+++ b/src/Quadrature.jl
@@ -321,10 +321,18 @@ function __init__()
                                maxevals = maxiters, kwargs...)
           end
 
-          if prob.nout == 1
-              val = out.integral[1]
+          if isinplace(prob) || prob.batch != 0
+              if prob.nout == 1
+                  val = out.integral[1]
+              else
+                  val = out.integral
+              end
           else
-              val = out.integral
+              if prob.nout == 1 && prob.f(prob.lb, prob.p) isa Number
+                  val = out.integral[1]
+              else
+                  val = out.integral
+              end
           end
 
           DiffEqBase.build_solution(prob,alg,val,out.error,

--- a/src/Quadrature.jl
+++ b/src/Quadrature.jl
@@ -160,7 +160,12 @@ function __init__()
                         # if isinplace(prob)
                         #      val = [_val]
                         # end
-                        val = isinplace(prob) ? [_val] : _val
+                        if isinplace(prob) || !isa(prob.f(prob.lb,prob.p), Number)
+                            val = [_val]
+                        else
+                            val = _val
+                        end
+                        # val = (isinplace(prob) || !isa(prob.f(prob.lb,prob.p), Number)) ? [_val] : _val
                         #     val = prob.f(prob.lb,prob.p) isa Number ? _val : [_val]
                         # end
                      end

--- a/src/Quadrature.jl
+++ b/src/Quadrature.jl
@@ -173,7 +173,11 @@ function __init__()
                     if isinplace(prob)
                         f = (x,dx) -> prob.f(dx,x,prob.p)
                     elseif prob.lb isa Number
-                        f = (x,dx) -> (dx .= prob.f(x',prob.p))
+                        if prob.f([prob.lb prob.ub], prob.p) isa Vector
+                            f = (x,dx) -> (dx .= prob.f(x',prob.p))
+                        else
+                            f = (x,dx) -> (dx .= prob.f(x',prob.p)')
+                        end
                     else
                         f = (x,dx) -> (dx .= prob.f(x,prob.p))
                     end
@@ -301,8 +305,14 @@ function __init__()
                           dx .*= prod((y)->y[1]-y[2],zip(ub,lb))
                       end
                   else
-                      f = function (x,dx)
-                          dx .= prob.f(scale_x(ub,lb,x),p)' .* prod((y)->y[1]-y[2],zip(ub,lb))
+                      if prob.f([prob.lb prob.ub], prob.p) isa Vector
+                          f = function (x,dx)
+                              dx .= prob.f(scale_x(ub,lb,x),p)' .* prod((y)->y[1]-y[2],zip(ub,lb))
+                          end
+                      else
+                          f = function (x,dx)
+                              dx .= prob.f(scale_x(ub,lb,x),p) .* prod((y)->y[1]-y[2],zip(ub,lb))
+                          end
                       end
                   end
               else

--- a/src/Quadrature.jl
+++ b/src/Quadrature.jl
@@ -171,7 +171,11 @@ function __init__()
                      end
                 else
                     if isinplace(prob)
-                        f = (x,dx) -> prob.f(dx,x,prob.p)
+                        f = (x,dx) -> prob.f(dx',x,prob.p)
+                        # f = function (x,dx)
+                        #     @show size(x), size(dx)
+                        #     prob.f(dx',x,prob.p)
+                        # end
                     elseif prob.lb isa Number
                         if prob.f([prob.lb prob.ub], prob.p) isa Vector
                             f = (x,dx) -> (dx .= prob.f(x',prob.p))

--- a/src/Quadrature.jl
+++ b/src/Quadrature.jl
@@ -125,18 +125,19 @@ function __init__()
                         dx = zeros(1)
                         f = (x) -> (prob.f(dx,x,prob.p); dx[1])
                     else
-                        f = (x) -> prob.f(x,prob.p)
+                        f = (x) -> prob.f(x,prob.p)[1]
                     end
                     if prob.lb isa Number
                         if alg isa CubatureJLh
-                            val,err = Cubature.hquadrature(f, prob.lb, prob.ub;
+                            _val,err = Cubature.hquadrature(f, prob.lb, prob.ub;
                                                            reltol=reltol, abstol=abstol,
                                                            maxevals=maxiters)
                         else
-                            val,err = Cubature.pquadrature(f, prob.lb, prob.ub;
+                            _val,err = Cubature.pquadrature(f, prob.lb, prob.ub;
                                                            reltol=reltol, abstol=abstol,
                                                            maxevals=maxiters)
                         end
+                        val = prob.f(prob.lb,prob.p) isa Number ? _val : [_val]
                     else
                         if alg isa CubatureJLh
                             val,err = Cubature.hcubature(f, prob.lb, prob.ub;
@@ -182,9 +183,9 @@ function __init__()
                  if prob.batch == 0
                      if isinplace(prob)
                          dx = similar(a)
-                         f = (x,dx) -> (prob.f(dx,x,p); dx)
+                         f = (x,dx) -> (prob.f(dx,x,prob.p); dx)
                      else
-                         f = (x,dx) -> (dx .= prob.f(x,p))
+                         f = (x,dx) -> (dx .= prob.f(x,prob.p))
                      end
                      if prob.lb isa Number
                          if alg isa CubatureJLh

--- a/src/Quadrature.jl
+++ b/src/Quadrature.jl
@@ -336,7 +336,12 @@ function __init__()
                   if isinplace(prob)
                       f = function (x,dx)
                           #todo scale_x!
-                          prob.f(dx',scale_x!(view(_x,1:size(x,1),1:size(x,2)),ub,lb,x),p)
+                          # @show size(x)
+                          # @show size(dx)
+                          # @show size(scale_x(ub,lb,x))
+                          # prob.f(dx',scale_x!(view(_x,1:size(x,1),1:size(x,2)),ub,lb,x),p)
+                          # prob.f(dx',scale_x(ub,lb,x),p)  #broken vector iip
+                          prob.f(dx,scale_x(ub,lb,x),p)   #broken nout = 1 iip
                           dx .*= prod((y)->y[1]-y[2],zip(ub,lb))
                       end
                   else

--- a/src/Quadrature.jl
+++ b/src/Quadrature.jl
@@ -71,7 +71,7 @@ function DiffEqBase.solve(prob::QuadratureProblem,::HCubatureJL,args...;
         f = (x) -> prob.f(x,p)
     end
     @assert prob.batch == 0
-    @assert prob.nout == 1
+
     if prob.lb isa Number
         val,err = hquadrature(f, prob.lb, prob.ub;
                             rtol=reltol, atol=abstol,

--- a/src/Quadrature.jl
+++ b/src/Quadrature.jl
@@ -176,10 +176,23 @@ function __init__()
                         if prob.f([prob.lb prob.ub], prob.p) isa Vector
                             f = (x,dx) -> (dx .= prob.f(x',prob.p))
                         else
-                            f = (x,dx) -> (dx .= prob.f(x',prob.p)')
+                            f = function (x,dx)
+                                dx[:] = prob.f(x',prob.p)
+                            end
                         end
                     else
-                        f = (x,dx) -> (dx .= prob.f(x,prob.p))
+                        # @show typeof(prob.f([prob.lb prob.ub], prob.p))
+                        if prob.f([prob.lb prob.ub], prob.p) isa Vector
+                            f = (x,dx) -> (dx .= prob.f(x,prob.p))
+                        else
+                            f = function (x,dx)
+                                # @show size(x), size(dx), size(prob.f(x,prob.p)[:])
+                                # @show x
+                                # @show dx
+                                # @show prob.f(x,prob.p)'
+                                dx .= prob.f(x,prob.p)[:]
+                            end
+                        end
                     end
                     if prob.lb isa Number
                         if alg isa CubatureJLh

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,7 +182,7 @@ end
     lb,ub = (1,3)
     for i in 1:length(integrands_v)
         for nout = 1:4
-            prob = QuadratureProblem((x,p) -> integrands_v[i](x,p,nout=nout),lb,ub)
+            prob = QuadratureProblem((x,p) -> integrands_v[i](x,p,nout=nout),lb,ub, nout = nout)
             for alg in algs
                 req = alg_req[alg]
                 if req.min_dim > 1 || req.nout < nout
@@ -200,7 +200,7 @@ end
 #     for i in 1:length(integrands_v)
 #         for dim = 1:5
 #             lb, ub = (ones(dim), 3ones(dim))
-#             prob = QuadratureProblem(integrands_v[i],lb,ub)
+#             prob = QuadratureProblem(integrands_v[i],lb,ub,nout = nout)
 #             for alg in algs
 #                 req = alg_req[alg]
 #                 if dim > req.max_dim || dim < req.min_dim || req.nout < nout || alg isa QuadGKJL  #QuadGKJL requires numbers, not single element arrays
@@ -218,7 +218,7 @@ end
 #     for i in 1:length(iip_integrands_v)
 #         for dim = 1:5
 #             lb, ub = (ones(dim), 3ones(dim))
-#             prob = QuadratureProblem(iip_integrands_v[i],lb,ub)
+#             prob = QuadratureProblem(iip_integrands_v[i],lb,ub,nout = nout)
 #             _sol = solve(prob,CubatureJLh())
 #             for alg in algs
 #                 req = alg_req[alg]
@@ -237,7 +237,7 @@ end
 #     (lb,ub) = (1,3)
 #     (dim, nout) = (1,1)
 #     for i in 1:length(integrands_v)
-#         prob = QuadratureProblem(batch_f(integrands_v[i]),lb,ub,batch=10)
+#         prob = QuadratureProblem(batch_f(integrands_v[i]),lb,ub,batch=10,nout = nout)
 #         for alg in algs
 #             req = alg_req[alg]
 #             if req.min_dim > 1 || !req.allows_batch || req.nout < nout
@@ -255,7 +255,7 @@ end
 #     for i in 1:length(integrands_v)
 #         for dim = 1:5
 #             (lb,ub) = (ones(dim),3ones(dim))
-#             prob = QuadratureProblem(batch_f(integrands_v[i]),lb,ub,batch=10)
+#             prob = QuadratureProblem(batch_f(integrands_v[i]),lb,ub,batch=10,nout = nout)
 #             for alg in algs
 #                 req = alg_req[alg]
 #                 if dim > req.max_dim || dim < req.min_dim || !req.allows_batch || req.nout < nout
@@ -274,7 +274,7 @@ end
 #     for i in 1:length(iip_integrands_v)
 #         for dim = 1:5
 #             (lb,ub) = (ones(dim),3ones(dim))
-#             prob = QuadratureProblem(batch_iip_f(integrands_v[i]),lb,ub,batch=10)
+#             prob = QuadratureProblem(batch_iip_f(integrands_v[i]),lb,ub,batch=10,nout = nout)
 #             for alg in algs
 #                 req = req = alg_req[alg]
 #                 if dim > req.max_dim || dim < req.min_dim || !req.allows_batch || !req.allows_iip || req.nout < nout

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,22 +61,22 @@ batch_iip_f(f) = (fevals,pts,p) -> begin
   nothing
 end
 
-# alg = CubatureJLh()
-alg = CubaSUAVE()
+alg = CubatureJLh()
+# alg = CubaSUAVE()
 # alg = HCubatureJL()
 ndim = 1
 nout = 1
-# lb,ub = ([0.0],[1.0])
-lb,ub = (1,3)
+lb,ub = ([0.0],[1.0])
+# lb,ub = (1,3)
 i = 1
-batch = 10
+batch = 0
 
 
-# f = (x,p) -> begin @show x; integrands_v[i](x,p,nout=nout); end
+f = (x,p) -> integrands_v[i](x,p,nout=nout)
 # f = (x,p) -> iip_integrands_v[i](x,p,nout=nout)
 # f = (dx,x,p) ->iip_integrands_v[i](dx,x,p,nout=nout)
-f = batch_f(integrands[i])
-x = [3.0]; dx = similar(x); f(x,1)
+# f = batch_f(integrands[i])
+# x = [3.0]; dx = similar(x); f(x,1)
 prob = QuadratureProblem(f,lb,ub, nout=1,batch=batch)
 @show v1 = solve(prob,alg,reltol=1e-4,abstol=1e-4).u
 # Juno.@enter solve(prob,alg,reltol=1e-4,abstol=1e-4)
@@ -249,7 +249,11 @@ end
                         continue
                     end
                     @info "Dimension = 1, Alg = $alg, Integrand = $i, Output Dimension = $nout"
-                    sol = solve(prob,alg,reltol=reltol,abstol=abstol)
+                    if alg isa HCubatureJL  && dim == 1 # HCubature library requires finer tol to pass test. When requiring array outputs for iip integrands
+                        sol = solve(prob,alg,reltol=1e-5,abstol=1e-5)
+                    else
+                        sol = solve(prob,alg,reltol=reltol,abstol=abstol)
+                    end
                     @test sol.u ≈ exact_sol_v[i](dim,nout,lb,ub) rtol = 1e-2
                 end
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,16 +55,19 @@ batch_iip_f(f) = (fevals,pts,p) -> begin
   nothing
 end
 
-alg = CubatureJLh()
+# alg = CubatureJLh()
+alg = CubaSUAVE()
 ndim = 1
-nout = 2
+nout = 1
 lb,ub = (0.0,1.0)
 i = 2
-f = (x,p) -> begin @show x; integrands_v[i](x,p,nout=nout); end
+# f = (x,p) -> begin @show x; integrands_v[i](x,p,nout=nout); end
+f = (x,p) -> integrands_v[i](x,p,nout=nout)
 prob = QuadratureProblem(f,lb,ub,nout=nout)
 @show v1 = solve(prob,alg,reltol=1e-3,abstol=1e-3).u
 @show v2 = hquadrature(nout, (x,v) -> v .= integrands_v[i](x,1.0,nout=nout) , lb, ub, reltol = 1e-3, abstol=1e-3)[1]
-v1≈v2
+@show v3 = suave((x,v) -> v .= integrands_v[i](x,1.0,nout=nout) , ndim, nout,rtol = 1e-3, atol=1e-3)[1]
+# v1≈v2
 
 ##
 @testset "Standard Single Dimension Integrands" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,10 +7,10 @@ max_dim_test = 2
 max_nout_test = 2
 reltol=1e-3
 abstol=1e-3
-
-# algs = [QuadGKJL(), HCubatureJL(), CubatureJLh(), CubatureJLp(), #VEGAS(), CubaVegas(),
-        # CubaSUAVE(),CubaDivonne(), CubaCuhre()]
-algs = [CubatureJLh()]
+#
+algs = [QuadGKJL(), HCubatureJL(), CubatureJLh(), CubatureJLp(), #VEGAS(), CubaVegas(),
+        CubaSUAVE(),CubaDivonne(), CubaCuhre()]
+# algs = [CubaSUAVE()]
 
 alg_req=Dict(QuadGKJL()=>     (nout=1,   allows_batch=false, min_dim=1, max_dim=1,   allows_iip = false),
              HCubatureJL()=>  (nout=Inf, allows_batch=false, min_dim=1, max_dim=Inf, allows_iip = true ),
@@ -28,7 +28,7 @@ integrands = [
              ]
 iip_integrands = [ (dx,x,p)-> (dx .= f(x,p)) for f ∈ integrands]
 
-## remove nout and make size(x)
+# remove nout and make size(x)
 integrands_v = [
                 (x,p; nout=2) -> collect(1.0:nout)
                 (x,p; nout=2) -> integrands[2](x,p)*collect(1.0:nout)
@@ -83,7 +83,7 @@ end
 # sol.u ≈ exact_sol_v[i](dim,nout,lb,ub)
 # integrands_v[i]([1],1,nout=1)
 
-##
+## adsf
 @testset "Standard Single Dimension Integrands" begin
     lb,ub = (1.0,3.0)
     nout = 1
@@ -308,18 +308,16 @@ end
     end
 end
 
-alg = CubatureJLh()
-i = 1
-(dim, nout) = (1,1)
-if dim == 1
-    (lb,ub) = (1.0,3.0)
-else
-    (lb,ub) = (ones(dim),3ones(dim))
-end
-batch_f_v(integrands_v[i],nout)([lb ub],1.0)
-prob = QuadratureProblem(batch_f_v(integrands_v[i],nout),lb,ub,batch=10,nout = nout)
-sol = solve(prob,alg,reltol=reltol,abstol=abstol)
-sol.u ≈ exact_sol_v[i](dim,nout,lb,ub)
+# alg = CubaSUAVE()
+# i = 1
+# (dim, nout) = (1,1)
+# # (lb,ub) = (1.0,3.0)
+# (lb,ub) = (ones(dim),3ones(dim))
+# batch_f_v(integrands_v[i],nout)([lb ub],1.0)
+# prob = QuadratureProblem(batch_f_v(integrands_v[i],nout),lb,ub,batch=10,nout = nout)
+# sol = solve(prob,alg,reltol=reltol,abstol=abstol)
+# # sol = @Juno.enter solve(prob,alg,reltol=reltol,abstol=abstol)
+# sol.u ≈ exact_sol_v[i](dim,nout,lb,ub)
 
 
 #

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,8 +29,8 @@ iip_integrands = [ (dx,x,p)-> (dx .= f(x,p)) for f ∈ integrands]
 
 ## remove nout and make size(x)
 integrands_v = [
-                (x,p; nout=2) -> collect(1:nout)
-                (x,p; nout=2) -> integrands[2](x,p)*collect(1:nout)
+                (x,p; nout=2) -> collect(1.0:nout)
+                (x,p; nout=2) -> integrands[2](x,p)*collect(1.0:nout)
                 ]
 iip_integrands_v = [ (dx,x,p; nout=2)-> (dx .= f(x,p,nout=nout)) for f ∈ integrands_v]
 
@@ -40,7 +40,7 @@ exact_sol = [
             ]
 
 exact_sol_v = [
-                (ndim, nout, lb, ub) -> prod(ub-lb) * collect(1:nout),
+                (ndim, nout, lb, ub) -> prod(ub-lb) * collect(1.0:nout),
                 (ndim, nout, lb, ub) -> exact_sol[2](ndim,nout,lb,ub) * collect(1:nout)
             ]
 
@@ -61,48 +61,76 @@ batch_iip_f(f) = (fevals,pts,p) -> begin
   nothing
 end
 
+batch_f_v(f, nout) = (pts,p) -> begin
+  fevals = zero(pts)
+  for i = 1:size(pts, 2)
+     # @show pts
+     x = pts[:,i]
+     # @show x, p, nout
+     fevals[:,i] = f(x,p,nout=nout)
+  end
+  fevals
+end
+
+(lb,ub) = (1.0,3.0)
+(dim, nout) = (1,1)
+alg = CubatureJLh()
+i = 2
+prob = QuadratureProblem(batch_f_v(integrands_v[i],nout),lb,ub,batch=10,nout = nout)
+sol = solve(prob,alg,reltol=reltol,abstol=abstol)
+sol.u ≈ exact_sol_v[i](dim,nout,lb,ub)
+integrands_v[i]([1],1,nout=1)
+
+
 alg = CubatureJLh()
 # alg = CubaSUAVE()
 # alg = HCubatureJL()
 ndim = 1
 nout = 1
-lb,ub = ([0.0],[1.0])
-# lb,ub = (1,3)
+# lb,ub = ([0.0],[1.0])
+lb,ub = (1,3)
 i = 1
-batch = 0
+batch = 10
 
 
-f = (x,p) -> integrands_v[i](x,p,nout=nout)
+# f = (x,p) -> integrands_v[i](x,p,nout=nout)
 # f = (x,p) -> iip_integrands_v[i](x,p,nout=nout)
 # f = (dx,x,p) ->iip_integrands_v[i](dx,x,p,nout=nout)
-# f = batch_f(integrands[i])
+f = batch_f_v(integrands_v[i],nout)
 # x = [3.0]; dx = similar(x); f(x,1)
-prob = QuadratureProblem(f,lb,ub, nout=1,batch=batch)
+f(fill(1,batch)', 1.0)
+prob = QuadratureProblem(f,lb,ub, nout=nout,batch=batch)
+
 @show v1 = solve(prob,alg,reltol=1e-4,abstol=1e-4).u
+# prob = QuadratureProblem(batch_f_v(integrands_v[i]),lb,ub,batch=10,nout = nout)
 # Juno.@enter solve(prob,alg,reltol=1e-4,abstol=1e-4)
 # @show v2 = hcubature(nout, (x,v) -> f(v,x,1.0) , lb, ub, reltol = reltol, abstol=abstol)[1]
+# @show v2 = Cubature.hcubature((x,v) -> v.=f(x',1.0)' , lb, ub, reltol = reltol, abstol=abstol)[1]
 # @show v2 = Cubature.hquadrature(nout, (x,v) -> f(v,x,1.0) , lb, ub, reltol = reltol, abstol=abstol)[1]
 # @show v3 = suave((x,v) -> v .= integrands_v[i](x,1.0,nout=nout) , ndim, nout,rtol = reltol, atol=1e-3)[1]
 # v1≈v2
-[exact_sol[i](ndim,1,lb,ub)]
+[exact_sol[i](ndim,nout,lb,ub)]
 
 ##
 @testset "Standard Single Dimension Integrands" begin
-    lb,ub = (1,3)
+    lb,ub = (1.0,3.0)
+    nout = 1
+    dim = 1
     for alg in algs
         if alg_req[alg].min_dim > 1
             continue
         end
         for i in 1:length(integrands)
             prob = QuadratureProblem(integrands[i],lb,ub)
-            @info "Dimension = 1, Alg = $alg, Integrand = $i"
+            @info "Alg = $alg, Integrand = $i, Dimension = $dim, Output Dimension = $nout"
             sol = solve(prob,alg,reltol=reltol,abstol=abstol)
-            @test sol.u ≈ exact_sol[i](1,1,lb,ub) rtol = 1e-2
+            @test sol.u ≈ exact_sol[i](dim,nout,lb,ub) rtol = 1e-2
         end
     end
 end
 
 @testset "Standard Integrands" begin
+    nout = 1
     for alg in algs
         req = alg_req[alg]
         for i in 1:length(integrands)
@@ -112,15 +140,16 @@ end
                 if dim > req.max_dim || dim < req.min_dim || alg isa QuadGKJL  #QuadGKJL requires numbers, not single element arrays
                     continue
                 end
-                @info "Dimension = $dim, Alg = $alg, Integrand = $i"
+                @info "Alg = $alg, Integrand = $i, Dimension = $dim, Output Dimension = $nout"
                 sol = solve(prob,alg,reltol=reltol,abstol=abstol)
-                @test sol.u ≈ exact_sol[i](dim,1,lb,ub) rtol = 1e-2
+                @test sol.u ≈ exact_sol[i](dim,nout,lb,ub) rtol = 1e-2
             end
         end
     end
 end
 
 @testset "In-place Standard Integrands" begin
+    nout = 1
     for alg in algs
         req = alg_req[alg]
         for i in 1:length(iip_integrands)
@@ -130,20 +159,20 @@ end
                 if dim > req.max_dim || dim < req.min_dim || alg isa QuadGKJL  #QuadGKJL requires numbers, not single element arrays
                     continue
                 end
-                @info "Dimension = $dim, Alg = $alg, Integrand = $i"
+                @info "Alg = $alg, Integrand = $i, Dimension = $dim, Output Dimension = $nout"
                 if alg isa HCubatureJL  && dim == 1 # HCubature library requires finer tol to pass test. When requiring array outputs for iip integrands
                     sol = solve(prob,alg,reltol=1e-5,abstol=1e-5)
                 else
                     sol = solve(prob,alg,reltol=reltol,abstol=abstol)
                 end
-                @test sol.u ≈ [exact_sol[i](dim,1,lb,ub)] rtol = 1e-2
+                @test sol.u ≈ [exact_sol[i](dim,nout,lb,ub)] rtol = 1e-2
             end
         end
     end
 end
 
 @testset "Batched Single Dimension Integrands" begin
-    (lb,ub) = (1,3)
+    (lb,ub) = (1.0,3.0)
     (dim, nout) = (1,1)
     for alg in algs
         req = alg_req[alg]
@@ -152,7 +181,7 @@ end
             if req.min_dim > 1 || !req.allows_batch
                 continue
             end
-            @info "Dimension = 1, Alg = $alg, Integrand = $i"
+            @info "Alg = $alg, Integrand = $i, Dimension = $dim, Output Dimension = $nout"
             sol = solve(prob,alg,reltol=reltol,abstol=abstol)
             @test sol.u ≈ [exact_sol[i](dim,nout,lb,ub)] rtol = 1e-2
         end
@@ -170,7 +199,7 @@ end
                     if dim > req.max_dim || dim < req.min_dim || !req.allows_batch
                         continue
                     end
-                    @info "Dimension = $dim, Alg = $alg, Integrand = $i"
+                    @info "Alg = $alg, Integrand = $i, Dimension = $dim, Output Dimension = $nout"
                     sol = solve(prob,alg,reltol=reltol,abstol=abstol)
                     @test sol.u ≈ [exact_sol[i](dim,nout,lb,ub)] rtol = 1e-2
                 end
@@ -189,7 +218,7 @@ end
                 if dim > req.max_dim || dim < req.min_dim || !req.allows_batch || !req.allows_iip
                     continue
                 end
-                @info "Dimension = $dim, Alg = $alg, Integrand = $i"
+                @info "Alg = $alg, Integrand = $i, Dimension = $dim, Output Dimension = $nout"
                 sol = solve(prob,alg,reltol=reltol,abstol=abstol)
                 @test sol.u ≈ [exact_sol[i](dim,nout,lb,ub)] rtol = 1e-2
             end
@@ -199,7 +228,8 @@ end
 
 ######## Vector Valued Integrands
 @testset "Standard Single Dimension Vector Integrands" begin
-    lb,ub = (1,3)
+    lb,ub = (1.0,3.0)
+    dim = 1
     for alg in algs
         req = alg_req[alg]
         for i in 1:length(integrands_v)
@@ -208,9 +238,9 @@ end
                 if req.min_dim > 1 || req.nout < nout
                     continue
                 end
-                @info "Dimension = 1, Alg = $alg, Integrand = $i, Output Dimension = $nout"
+                @info "Alg = $alg, Integrand = $i, Dimension = $dim, Output Dimension = $nout"
                 sol = solve(prob,alg,reltol=reltol,abstol=abstol)
-                @test sol.u ≈ exact_sol_v[i](1,nout,lb,ub) rtol = 1e-2
+                @test sol.u ≈ exact_sol_v[i](dim,nout,lb,ub) rtol = 1e-2
             end
         end
     end
@@ -227,7 +257,7 @@ end
                         continue
                     end
                     prob = QuadratureProblem((x,p) -> integrands_v[i](x,p,nout=nout),lb,ub, nout = nout)
-                    @info "Dimension = 1, Alg = $alg, Integrand = $i, Output Dimension = $nout"
+                    @info "Alg = $alg, Integrand = $i, Dimension = $dim, Output Dimension = $nout"
                     sol = solve(prob,alg,reltol=reltol,abstol=abstol)
                     @test sol.u ≈ exact_sol_v[i](dim,nout,lb,ub) rtol = 1e-2
                 end
@@ -237,18 +267,17 @@ end
 end
 
 @testset "In-place Standard Vector Integrands" begin
-    for i in 1:length(iip_integrands_v)
-        for dim = 1:max_dim_test
-            lb, ub = (ones(dim), 3ones(dim))
-            for nout = 1:max_nout_test
-                prob = QuadratureProblem((dx,x,p) ->iip_integrands_v[i](dx,x,p,nout=nout),lb,ub,nout = nout)
-                _sol = solve(prob,CubatureJLh())
-                for alg in algs
-                    req = alg_req[alg]
+    for alg in algs
+        req = alg_req[alg]
+        for i in 1:length(iip_integrands_v)
+            for dim = 1:max_dim_test
+                lb, ub = (ones(dim), 3ones(dim))
+                for nout = 1:max_nout_test
+                    prob = QuadratureProblem((dx,x,p) ->iip_integrands_v[i](dx,x,p,nout=nout),lb,ub,nout = nout)
                     if dim > req.max_dim || dim < req.min_dim || req.nout < nout || alg isa QuadGKJL  #QuadGKJL requires numbers, not single element arrays
                         continue
                     end
-                    @info "Dimension = 1, Alg = $alg, Integrand = $i, Output Dimension = $nout"
+                    @info "Alg = $alg, Integrand = $i, Dimension = $dim, Output Dimension = $nout"
                     if alg isa HCubatureJL  && dim == 1 # HCubature library requires finer tol to pass test. When requiring array outputs for iip integrands
                         sol = solve(prob,alg,reltol=1e-5,abstol=1e-5)
                     else
@@ -260,38 +289,50 @@ end
         end
     end
 end
-#
-# @testset "Batched Single Dimension Vector Integrands" begin
-#     (lb,ub) = (1,3)
-#     (dim, nout) = (1,1)
-#     for i in 1:length(integrands_v)
-#         prob = QuadratureProblem(batch_f(integrands_v[i]),lb,ub,batch=10,nout = nout)
-#         for alg in algs
-#             req = alg_req[alg]
-#             if req.min_dim > 1 || !req.allows_batch || req.nout < nout
-#                 continue
-#             end
-#             @info "Dimension = 1, Alg = $alg, Integrand = $i, Output Dimension = $nout"
-#             sol = solve(prob,alg,reltol=reltol,abstol=abstol)
-#             @test sol.u ≈ exact_sol_v[i](dim,nout,lb,ub) rtol = 1e-2
-#         end
-#     end
-# end
+
+@testset "Batched Single Dimension Vector Integrands" begin
+    (lb,ub) = (1.0,3.0)
+    (dim, nout) = (1,1)
+    for alg in algs
+        req = alg_req[alg]
+        for i in 1:length(integrands_v)
+            prob = QuadratureProblem(batch_f_v(integrands_v[i],nout),lb,ub,batch=10,nout = nout)
+            if req.min_dim > 1 || !req.allows_batch || req.nout < nout
+                continue
+            end
+            @info "Alg = $alg, Integrand = $i, Dimension = $dim, Output Dimension = $nout"
+            sol = solve(prob,alg,reltol=reltol,abstol=abstol)
+            # @show sol.u
+            # @show exact_sol_v[i](dim,nout,lb,ub)
+            @test sol.u ≈ exact_sol_v[i](dim,nout,lb,ub) rtol = 1e-2
+        end
+    end
+end
+# (lb,ub) = (1.0,3.0)
+# (dim, nout) = (1,1)
+# alg = CubaSUAVE()
+# i = 1
+# prob = QuadratureProblem(batch_f_v(integrands_v[i],nout),lb,ub,batch=10,nout = nout)
+# sol = solve(prob,alg,reltol=reltol,abstol=abstol)
+# sol.u ≈ exact_sol_v[i](dim,nout,lb,ub)
+
+
+
 #
 # @testset "Batched Standard Vector Integrands" begin
 #     nout = 1
-#     for i in 1:length(integrands_v)
-#         for dim = 1:5
-#             (lb,ub) = (ones(dim),3ones(dim))
-#             prob = QuadratureProblem(batch_f(integrands_v[i]),lb,ub,batch=10,nout = nout)
-#             for alg in algs
-#                 req = alg_req[alg]
+#     for alg in algs
+#         req = alg_req[alg]
+#         for i in 1:length(integrands_v)
+#             for dim = 1:5
+#                 (lb,ub) = (ones(dim),3ones(dim))
+#                 prob = QuadratureProblem(batch_f(integrands_v[i]),lb,ub,batch=10,nout = nout)
 #                 if dim > req.max_dim || dim < req.min_dim || !req.allows_batch || req.nout < nout
 #                     continue
 #                 end
 #                 @info "Dimension = 1, Alg = $alg, Integrand = $i, Output Dimension = $nout"
 #                 sol = solve(prob,alg,reltol=reltol,abstol=abstol)
-#                 @test sol.u ≈ exact_sol_v[i](dim,nout,lb,ub) rtol = 1e-2
+#                 @test sol.u ≈ [exact_sol_v[i](dim,nout,lb,ub)] rtol = 1e-2
 #             end
 #         end
 #     end
@@ -299,18 +340,18 @@ end
 #
 # @testset "In-Place Batched Standard Vector Integrands" begin
 #     nout = 1
-#     for i in 1:length(iip_integrands_v)
-#         for dim = 1:5
-#             (lb,ub) = (ones(dim),3ones(dim))
-#             prob = QuadratureProblem(batch_iip_f(integrands_v[i]),lb,ub,batch=10,nout = nout)
-#             for alg in algs
-#                 req = req = alg_req[alg]
+#     for alg in algs
+#         req = req = alg_req[alg]
+#         for i in 1:length(iip_integrands_v)
+#             for dim = 1:5
+#                 (lb,ub) = (ones(dim),3ones(dim))
+#                 prob = QuadratureProblem(batch_iip_f(integrands_v[i]),lb,ub,batch=10,nout = nout)
 #                 if dim > req.max_dim || dim < req.min_dim || !req.allows_batch || !req.allows_iip || req.nout < nout
 #                     continue
 #                 end
 #                 @info "Dimension = 1, Alg = $alg, Integrand = $i, Output Dimension = $nout"
 #                 sol = solve(prob,alg,reltol=reltol,abstol=abstol)
-#                 @test sol.u ≈ exact_sol_v[i](dim,nout,lb,ub) rtol = 1e-2
+#                 @test sol.u ≈ [exact_sol_v[i](dim,nout,lb,ub)] rtol = 1e-2
 #             end
 #         end
 #     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ abstol=1e-3
 #
 algs = [QuadGKJL(), HCubatureJL(), CubatureJLh(), CubatureJLp(), #VEGAS(), CubaVegas(),
         CubaSUAVE(),CubaDivonne(), CubaCuhre()]
-# algs = [CubatureJLh()]
+# algs = [CubaSUAVE()]
 
 alg_req=Dict(QuadGKJL()=>     (nout=1,   allows_batch=false, min_dim=1, max_dim=1,   allows_iip = false),
              HCubatureJL()=>  (nout=Inf, allows_batch=false, min_dim=1, max_dim=Inf, allows_iip = true ),
@@ -288,14 +288,6 @@ end
         end
     end
 end
-# (lb,ub) = (1.0,3.0)
-# (dim, nout) = (1,1)
-# alg = CubaSUAVE()
-# i = 1
-# prob = QuadratureProblem(batch_f_v(integrands_v[i],nout),lb,ub,batch=10,nout = nout)
-# sol = solve(prob,alg,reltol=reltol,abstol=abstol)
-# sol.u ≈ exact_sol_v[i](dim,nout,lb,ub)
-
 
 @testset "Batched Standard Vector Integrands" begin
     nout = 1
@@ -335,13 +327,13 @@ end
     end
 end
 
-# alg = CubatureJLh()
+# alg = CubaSUAVE()
 # i = 1
 # (dim, nout) = (1,1)
 # # (lb,ub) = (1.0,3.0)
 # (lb,ub) = (ones(dim),3ones(dim))
 # batch_f_v(integrands_v[i],nout)([lb ub],1.0)
 # prob = QuadratureProblem(batch_iip_f_v(integrands_v[i],nout),lb,ub,batch=10,nout = nout)
-# # sol = solve(prob,alg,reltol=reltol,abstol=abstol)
+# sol = solve(prob,alg,reltol=reltol,abstol=abstol)
 # sol = @Juno.enter solve(prob,alg,reltol=reltol,abstol=abstol)
 # sol.u ≈ exact_sol_v[i](dim,nout,lb,ub)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,18 +55,18 @@ batch_iip_f(f) = (fevals,pts,p) -> begin
   nothing
 end
 
-# alg = CubatureJLh()
-alg = CubaSUAVE()
+alg = CubatureJLh()
+# alg = CubaSUAVE()
 ndim = 1
 nout = 1
-lb,ub = (0.0,1.0)
-i = 2
+lb,ub = ([0.0],[1.0])
+i = 1
 # f = (x,p) -> begin @show x; integrands_v[i](x,p,nout=nout); end
 f = (x,p) -> integrands_v[i](x,p,nout=nout)
 prob = QuadratureProblem(f,lb,ub,nout=nout)
 @show v1 = solve(prob,alg,reltol=1e-3,abstol=1e-3).u
 @show v2 = hquadrature(nout, (x,v) -> v .= integrands_v[i](x,1.0,nout=nout) , lb, ub, reltol = 1e-3, abstol=1e-3)[1]
-@show v3 = suave((x,v) -> v .= integrands_v[i](x,1.0,nout=nout) , ndim, nout,rtol = 1e-3, atol=1e-3)[1]
+# @show v3 = suave((x,v) -> v .= integrands_v[i](x,1.0,nout=nout) , ndim, nout,rtol = 1e-3, atol=1e-3)[1]
 # v1≈v2
 
 ##
@@ -196,23 +196,25 @@ end
     end
 end
 
-# @testset "Standard Vector Integrands" begin
-#     for i in 1:length(integrands_v)
-#         for dim = 1:5
-#             lb, ub = (ones(dim), 3ones(dim))
-#             prob = QuadratureProblem(integrands_v[i],lb,ub,nout = nout)
-#             for alg in algs
-#                 req = alg_req[alg]
-#                 if dim > req.max_dim || dim < req.min_dim || req.nout < nout || alg isa QuadGKJL  #QuadGKJL requires numbers, not single element arrays
-#                     continue
-#                 end
-#                 @info "Dimension = 1, Alg = $alg, Integrand = $i, Output Dimension = $nout"
-#                 sol = solve(prob,alg,reltol=1e-3,abstol=1e-3)
-#                 @test sol.u ≈ exact_sol_v[i](dim,nout,lb,ub) rtol = 1e-2
-#             end
-#         end
-#     end
-# end
+@testset "Standard Vector Integrands" begin
+    for i in 1:length(integrands_v)
+        for dim = 1:3
+            lb, ub = (ones(dim), 3ones(dim))
+            for nout = 1:3
+                prob = QuadratureProblem((x,p) -> integrands_v[i](x,p,nout=nout),lb,ub, nout = nout)
+                for alg in algs
+                    req = alg_req[alg]
+                    if dim > req.max_dim || dim < req.min_dim || req.nout < nout || alg isa QuadGKJL  #QuadGKJL requires numbers, not single element arrays
+                        continue
+                    end
+                    @info "Dimension = 1, Alg = $alg, Integrand = $i, Output Dimension = $nout"
+                    sol = solve(prob,alg,reltol=1e-3,abstol=1e-3)
+                    @test sol.u ≈ exact_sol_v[i](dim,nout,lb,ub) rtol = 1e-2
+                end
+            end
+        end
+    end
+end
 #
 # @testset "In-place Standard Vector Integrands" begin
 #     for i in 1:length(iip_integrands_v)


### PR DESCRIPTION
This PR mirrors previous tests but for vector integrands. Quadrature methods have been updated to pass all tests! Fixes #2 and fixes #16 

### HCubatureJL() Tolerances
For some reason for integrands of R^n->R^m where either n or m > 1, the tolerances are not being adhered to. Must be something upstream. Tighter tolerances are required to pass tests. 
