### PR TITLE
Restoring Zygote differentiability

### DIFF
--- a/ext/IntegralsZygoteExt.jl
+++ b/ext/IntegralsZygoteExt.jl
@@ -22,7 +22,8 @@ function ChainRulesCore.rrule(::Type{<:IntegralProblem}, f, domain, p; kwargs...
     return prob, IntegralProblem_pullback
 end
 
-function ChainRulesCore.rrule(::Type{IntegralProblem{iip}}, f, domain, p; kwargs...) where {iip}
+function ChainRulesCore.rrule(
+        ::Type{IntegralProblem{iip}}, f, domain, p; kwargs...) where {iip}
     prob = IntegralProblem{iip}(f, domain, p; kwargs...)
     function IntegralProblem_iip_pullback(Δ)
         ddomain = hasproperty(Δ, :domain) ? Δ.domain : NoTangent()


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

As described in #281 , Zygote was failing in differentiating IntegralProblems. This PR fixes that, by including a couple of rrules for this.
**Disclosure:** I initially used Claude Sonnet 4.5.
I ensured that the tests were failing _before_ the fix on 1.12 and that they were running afterwards.
I also used JuliaFormatter to ensure consistent foramtting with SciML style.