### PR TITLE
Documentation improvements: add missing tutorial, fix link, and fix terminology

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -1,6 +1,7 @@
 pages = ["index.md",
     "Tutorials" => Any["tutorials/numerical_integrals.md",
-        "tutorials/differentiating_integrals.md"],
+        "tutorials/differentiating_integrals.md",
+        "tutorials/caching_interface.md"],
     "Basics" => Any["basics/IntegralProblem.md",
         "basics/IntegralFunction.md",
         "basics/SampledIntegralProblem.md",

--- a/docs/src/tutorials/caching_interface.md
+++ b/docs/src/tutorials/caching_interface.md
@@ -49,7 +49,7 @@ The caching interface is intended for updating `p` and `domain`.
 Note that the types of these variables is not allowed to change.
 If it is necessary to change the integrand `f` instead of defining a new
 `IntegralProblem`, consider using
-[FunctionWrappers.jl](https://github.com/yuyichao/FunctionWrappers.jl).
+[FunctionWrappers.jl](https://github.com/JuliaLang/FunctionWrappers.jl).
 
 ## Caching for sampled integral problems
 

--- a/docs/src/tutorials/numerical_integrals.md
+++ b/docs/src/tutorials/numerical_integrals.md
@@ -50,9 +50,9 @@ Another way to think about this is that the integrand is now a vector valued fun
 In general, we should be able to integrate any type that is in a vector space
 and supports addition and scalar multiplication, although Integrals.jl allows
 scalars and arrays.
-In the above example, the integrand was defined out-of-position.
+In the above example, the integrand was defined out-of-place.
 This means that a new output vector is created every time the function `f` is called.
-If we do not  want these allocations, we can also define `f` in-position.
+If we do not want these allocations, we can also define `f` in-place.
 
 ```@example integrate3
 using Integrals, Cubature
@@ -70,7 +70,7 @@ sol.u
 where `y` is a cache to store the evaluation of the integrand and `prototype` is
 an instance of `y` with the desired type and shape.
 We needed to change the algorithm to `CubatureJLh()`
-because `HCubatureJL()` does not support in-position under the hood.
+because `HCubatureJL()` does not support in-place under the hood.
 `f` evaluates the integrand at a certain point,
 but most adaptive quadrature algorithms need to evaluate the integrand at multiple points
 in each step of the algorithm.
@@ -97,7 +97,7 @@ Both `u` and `y` changed from vectors to matrices,
 where each column is respectively a point the integrand is evaluated at or
 the evaluation of the integrand at the corresponding point.
 The `prototype` now has an extra dimension for batching that can be of size zero.
-Try to create yourself an out-of-position version of the above problem.
+Try to create yourself an out-of-place version of the above problem.
 For the full details of the batching interface, see the [problem page](@ref prob).
 
 If we would like to compare the results against Cuba.jl's `Cuhre` method, then


### PR DESCRIPTION
## Summary

- Add missing `caching_interface.md` tutorial to the navigation in `pages.jl`
  - This tutorial existed in the docs/src/tutorials folder but was not accessible from the docs navigation
- Fix FunctionWrappers.jl link that was returning a 301 redirect
  - Updated from `yuyichao/FunctionWrappers.jl` to `JuliaLang/FunctionWrappers.jl`
- Fix inconsistent terminology in `numerical_integrals.md`
  - Changed "in-position"/"out-of-position" to "in-place"/"out-of-place" to match standard Julia terminology used in the rest of the documentation
- Fix double space typo in `numerical_integrals.md`

## Test plan

- [x] Docs build successfully locally
- [x] Verified the caching_interface tutorial appears in the build output
- [x] Verified the FunctionWrappers.jl link is correctly updated in the HTML output
- [x] Verified no instances of "in-position" remain in the build

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)