### PR TITLE
Documentation: fix IntegralProblem argument description and clarify batch terminology

### DIFF
--- a/docs/src/basics/IntegralProblem.md
+++ b/docs/src/basics/IntegralProblem.md
@@ -5,16 +5,17 @@ SciMLBase.IntegralProblem
 ```
 
 The correct shape of the variables (inputs) `u` and the values (outputs) `y` of the integrand `f`
-depends on whether batching is used.
+depends on whether batching is used. Batching is enabled by using
+[`BatchIntegralFunction`](@ref func) instead of [`IntegralFunction`](@ref func).
 
-**If `batch == 0`**
+**Without batching (using `IntegralFunction`)**
 
 |                       | single variable `f`              | multiple variable `f`            |
 |:--------------------- |:-------------------------------- |:-------------------------------- |
 | **scalar valued `f`** | `u` is a scalar, `y` is a scalar | `u` is a vector, `y` is a scalar |
 | **vector valued `f`** | `u` is a scalar, `y` is a vector | `u` is a vector, `y` is a vector |
 
-**If `batch > 0`**
+**With batching (using `BatchIntegralFunction`)**
 
 |                       | single variable `f`              | multiple variable `f`            |
 |:--------------------- |:-------------------------------- |:-------------------------------- |

--- a/docs/src/tutorials/numerical_integrals.md
+++ b/docs/src/tutorials/numerical_integrals.md
@@ -19,7 +19,8 @@ sol.u
 ```
 
 where the first argument of `IntegralProblem` is the integrand,
-the second argument is the lower bound, and the third argument is the upper bound.
+the second argument is the domain (a tuple of lower and upper bounds),
+and the optional third argument contains the parameters.
 `p` are the parameters of the integrand. In this case, there are no parameters,
 but still `f` must be defined as `f(x,p)` and **not** `f(x)`.
 For an example with parameters, see the next tutorial.


### PR DESCRIPTION
## Summary

- Fix incorrect description of IntegralProblem constructor arguments in the numerical integrals tutorial
- Update IntegralProblem.md to use modern API terminology instead of deprecated parameter notation

### Changes:

1. **docs/src/tutorials/numerical_integrals.md**: Fixed the description that incorrectly stated the second argument is "the lower bound" and third is "the upper bound". The second argument is actually `domain` (a tuple of `(lb, ub)`), and the optional third argument contains the parameters.

2. **docs/src/basics/IntegralProblem.md**: Replaced the deprecated `batch == 0` / `batch > 0` terminology with clearer references to `IntegralFunction` and `BatchIntegralFunction`, which is the modern way to enable batching.

## Test plan

- [x] Documentation builds successfully without new warnings
- [x] Changes are purely documentation corrections

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)