### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-format_markdown = true
-format_docstrings = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -9,34 +9,10 @@ on:
   pull_request:
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        julia-version: [1]
-        julia-arch: [x86]
-        os: [ubuntu-latest]
+  runic:
+    runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
         with:
-          version: ${{ matrix.julia-version }}
-
-      - uses: actions/checkout@v6
-      - name: Install JuliaFormatter and format
-        # This will use the latest version by default but you can set the version like so:
-        #
-        # julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="0.13.0"))'
-        run: |
-          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter"))'
-          julia  -e 'using JuliaFormatter; format(".", verbose=true)'
-      - name: Format check
-        run: |
-          julia -e '
-          out = Cmd(`git diff --name-only`) |> read |> String
-          if out == ""
-              exit(0)
-          else
-              @error "Some files have not been formatted !!!"
-              write(stdout, out)
-              exit(1)
-          end'
+          version: '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,14 +5,20 @@ cp("./docs/Project.toml", "./docs/src/assets/Project.toml", force = true)
 
 include("pages.jl")
 
-makedocs(sitename = "Integrals.jl",
+makedocs(
+    sitename = "Integrals.jl",
     authors = "Chris Rackauckas",
     modules = [Integrals, Integrals.SciMLBase],
     clean = true, doctest = false, linkcheck = true,
     warnonly = [:missing_docs],
-    format = Documenter.HTML(assets = ["assets/favicon.ico"],
-        canonical = "https://docs.sciml.ai/Integrals/stable/"),
-    pages = pages)
+    format = Documenter.HTML(
+        assets = ["assets/favicon.ico"],
+        canonical = "https://docs.sciml.ai/Integrals/stable/"
+    ),
+    pages = pages
+)
 
-deploydocs(repo = "github.com/SciML/Integrals.jl.git";
-    push_preview = true)
+deploydocs(
+    repo = "github.com/SciML/Integrals.jl.git";
+    push_preview = true
+)

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -1,12 +1,17 @@
-pages = ["index.md",
-    "Tutorials" => Any["tutorials/numerical_integrals.md",
+pages = [
+    "index.md",
+    "Tutorials" => Any[
+        "tutorials/numerical_integrals.md",
         "tutorials/differentiating_integrals.md",
         "tutorials/caching_interface.md",
-        "tutorials/infinity_transforms.md"],
-    "Basics" => Any["basics/IntegralProblem.md",
+        "tutorials/infinity_transforms.md",
+    ],
+    "Basics" => Any[
+        "basics/IntegralProblem.md",
         "basics/IntegralFunction.md",
         "basics/SampledIntegralProblem.md",
         "basics/solve.md",
-        "basics/FAQ.md"],
-    "Solvers" => Any["solvers/IntegralSolvers.md"]
+        "basics/FAQ.md",
+    ],
+    "Solvers" => Any["solvers/IntegralSolvers.md"],
 ]

--- a/ext/IntegralsArblibExt.jl
+++ b/ext/IntegralsArblibExt.jl
@@ -5,7 +5,8 @@ using Integrals
 
 function Integrals.__solvebp_call(
         prob::IntegralProblem, alg::ArblibJL, sensealg, domain, p;
-        reltol = 1e-8, abstol = 1e-8, maxiters = nothing)
+        reltol = 1.0e-8, abstol = 1.0e-8, maxiters = nothing
+    )
     lb_, ub_ = domain
     lb, ub = map(first, domain)
     if !isone(length(lb_)) || !isone(length(ub_))
@@ -18,16 +19,20 @@ function Integrals.__solvebp_call(
         @assert res isa eltype(prob.f.integrand_prototype) "Arblib require inplace prototypes to store Acb elements"
         y_ = similar(prob.f.integrand_prototype)
         f_ = (y, x; kws...) -> (prob.f(y_, x, p; kws...); Arblib.set!(y, only(y_)))
-        val = Arblib.integrate!(f_, res, lb, ub, atol = abstol, rtol = reltol,
+        val = Arblib.integrate!(
+            f_, res, lb, ub, atol = abstol, rtol = reltol,
             check_analytic = alg.check_analytic, take_prec = alg.take_prec,
-            warn_on_no_convergence = alg.warn_on_no_convergence, opts = alg.opts)
+            warn_on_no_convergence = alg.warn_on_no_convergence, opts = alg.opts
+        )
     else
         f_ = (x; kws...) -> only(prob.f(x, p; kws...))
-        val = Arblib.integrate(f_, lb, ub, atol = abstol, rtol = reltol,
+        val = Arblib.integrate(
+            f_, lb, ub, atol = abstol, rtol = reltol,
             check_analytic = alg.check_analytic, take_prec = alg.take_prec,
-            warn_on_no_convergence = alg.warn_on_no_convergence, opts = alg.opts)
+            warn_on_no_convergence = alg.warn_on_no_convergence, opts = alg.opts
+        )
     end
-    SciMLBase.build_solution(prob, alg, val, get_radius(val), retcode = ReturnCode.Success)
+    return SciMLBase.build_solution(prob, alg, val, get_radius(val), retcode = ReturnCode.Success)
 end
 
 function get_radius(ball)

--- a/ext/IntegralsCubaExt.jl
+++ b/ext/IntegralsCubaExt.jl
@@ -2,15 +2,17 @@ module IntegralsCubaExt
 
 using Integrals, Cuba
 import Integrals: transformation_if_inf,
-                  scale_x, scale_x!, CubaVegas, AbstractCubaAlgorithm,
-                  CubaSUAVE, CubaDivonne, CubaCuhre
+    scale_x, scale_x!, CubaVegas, AbstractCubaAlgorithm,
+    CubaSUAVE, CubaDivonne, CubaCuhre
 
-function Integrals.__solvebp_call(prob::IntegralProblem, alg::AbstractCubaAlgorithm,
+function Integrals.__solvebp_call(
+        prob::IntegralProblem, alg::AbstractCubaAlgorithm,
         sensealg,
         domain, p;
-        reltol = 1e-4, abstol = 1e-12,
-        maxiters = 1000000)
-    @assert maxiters>=1000 "maxiters for $alg should be larger than 1000"
+        reltol = 1.0e-4, abstol = 1.0e-12,
+        maxiters = 1000000
+    )
+    @assert maxiters >= 1000 "maxiters for $alg should be larger than 1000"
     lb, ub = domain
     mid = (lb + ub) / 2
     ndim = length(mid)
@@ -43,7 +45,7 @@ function Integrals.__solvebp_call(prob::IntegralProblem, alg::AbstractCubaAlgori
                 function (u, _y)
                     y = @view(y_[ax..., begin:(begin + size(_y, 2) - 1)])
                     f(y, scale(u), p)
-                    _y .= reshape(y, size(_y)) .* vol
+                    return _y .= reshape(y, size(_y)) .* vol
                 end
             end
         else
@@ -73,31 +75,39 @@ function Integrals.__solvebp_call(prob::IntegralProblem, alg::AbstractCubaAlgori
     end
 
     out = if alg isa CubaVegas
-        Cuba.vegas(_f, ndim, ncomp; rtol = reltol,
+        Cuba.vegas(
+            _f, ndim, ncomp; rtol = reltol,
             atol = abstol, nvec = nvec,
             maxevals = maxiters,
             flags = alg.flags, seed = alg.seed, minevals = alg.minevals,
             nstart = alg.nstart, nincrease = alg.nincrease,
-            gridno = alg.gridno)
+            gridno = alg.gridno
+        )
     elseif alg isa CubaSUAVE
-        Cuba.suave(_f, ndim, ncomp; rtol = reltol,
+        Cuba.suave(
+            _f, ndim, ncomp; rtol = reltol,
             atol = abstol, nvec = nvec,
             maxevals = maxiters,
             flags = alg.flags, seed = alg.seed, minevals = alg.minevals,
-            nnew = alg.nnew, nmin = alg.nmin, flatness = alg.flatness)
+            nnew = alg.nnew, nmin = alg.nmin, flatness = alg.flatness
+        )
     elseif alg isa CubaDivonne
-        Cuba.divonne(_f, ndim, ncomp; rtol = reltol,
+        Cuba.divonne(
+            _f, ndim, ncomp; rtol = reltol,
             atol = abstol, nvec = nvec,
             maxevals = maxiters,
             flags = alg.flags, seed = alg.seed, minevals = alg.minevals,
             key1 = alg.key1, key2 = alg.key2, key3 = alg.key3,
             maxpass = alg.maxpass, border = alg.border,
-            maxchisq = alg.maxchisq, mindeviation = alg.mindeviation)
+            maxchisq = alg.maxchisq, mindeviation = alg.mindeviation
+        )
     elseif alg isa CubaCuhre
-        Cuba.cuhre(_f, ndim, ncomp; rtol = reltol,
+        Cuba.cuhre(
+            _f, ndim, ncomp; rtol = reltol,
             atol = abstol, nvec = nvec,
             maxevals = maxiters,
-            flags = alg.flags, minevals = alg.minevals, key = alg.key)
+            flags = alg.flags, minevals = alg.minevals, key = alg.key
+        )
     end
 
     # out.integral is a Vector{Float64}, but we want to return it to the shape of the integrand
@@ -117,8 +127,10 @@ function Integrals.__solvebp_call(prob::IntegralProblem, alg::AbstractCubaAlgori
         end
     end
 
-    SciMLBase.build_solution(prob, alg, val, out.error,
-        chi = out.probability, retcode = ReturnCode.Success)
+    return SciMLBase.build_solution(
+        prob, alg, val, out.error,
+        chi = out.probability, retcode = ReturnCode.Success
+    )
 end
 
 end

--- a/ext/IntegralsCubatureExt.jl
+++ b/ext/IntegralsCubatureExt.jl
@@ -4,11 +4,13 @@ using Integrals, Cubature
 
 using Integrals: scale_x, scale_x!, CubatureJLh, CubatureJLp, AbstractCubatureJLAlgorithm
 
-function Integrals.__solvebp_call(prob::IntegralProblem,
+function Integrals.__solvebp_call(
+        prob::IntegralProblem,
         alg::AbstractCubatureJLAlgorithm,
         sensealg, domain, p;
-        reltol = 1e-8, abstol = 1e-8,
-        maxiters = typemax(Int))
+        reltol = 1.0e-8, abstol = 1.0e-8,
+        maxiters = typemax(Int)
+    )
     lb, ub = domain
     mid = (lb + ub) / 2
 
@@ -16,7 +18,7 @@ function Integrals.__solvebp_call(prob::IntegralProblem,
     f = prob.f
     prototype = Integrals.get_prototype(prob)
 
-    @assert eltype(prototype)<:Real "Cubature.jl is only compatible with real-valued integrands"
+    @assert eltype(prototype) <: Real "Cubature.jl is only compatible with real-valued integrands"
 
     if f isa BatchIntegralFunction
         if prototype isa AbstractVector # this branch could be omitted since the following one should work similarly
@@ -36,26 +38,34 @@ function Integrals.__solvebp_call(prob::IntegralProblem,
             if mid isa Number
                 if alg isa CubatureJLh
                     val,
-                    err = Cubature.hquadrature_v(_f, lb, ub;
+                        err = Cubature.hquadrature_v(
+                        _f, lb, ub;
                         reltol = reltol, abstol = abstol,
-                        maxevals = maxiters)
+                        maxevals = maxiters
+                    )
                 else
                     val,
-                    err = Cubature.pquadrature_v(_f, lb, ub;
+                        err = Cubature.pquadrature_v(
+                        _f, lb, ub;
                         reltol = reltol, abstol = abstol,
-                        maxevals = maxiters)
+                        maxevals = maxiters
+                    )
                 end
             else
                 if alg isa CubatureJLh
                     val,
-                    err = Cubature.hcubature_v(_f, lb, ub;
+                        err = Cubature.hcubature_v(
+                        _f, lb, ub;
                         reltol = reltol, abstol = abstol,
-                        maxevals = maxiters)
+                        maxevals = maxiters
+                    )
                 else
                     val,
-                    err = Cubature.pcubature_v(_f, lb, ub;
+                        err = Cubature.pcubature_v(
+                        _f, lb, ub;
                         reltol = reltol, abstol = abstol,
-                        maxevals = maxiters)
+                        maxevals = maxiters
+                    )
                 end
             end
         elseif prototype isa AbstractArray
@@ -78,26 +88,34 @@ function Integrals.__solvebp_call(prob::IntegralProblem,
             if mid isa Number
                 if alg isa CubatureJLh
                     val_,
-                    err = Cubature.hquadrature_v(fdim, _f, lb, ub;
+                        err = Cubature.hquadrature_v(
+                        fdim, _f, lb, ub;
                         reltol = reltol, abstol = abstol,
-                        maxevals = maxiters, error_norm = alg.error_norm)
+                        maxevals = maxiters, error_norm = alg.error_norm
+                    )
                 else
                     val_,
-                    err = Cubature.pquadrature_v(fdim, _f, lb, ub;
+                        err = Cubature.pquadrature_v(
+                        fdim, _f, lb, ub;
                         reltol = reltol, abstol = abstol,
-                        maxevals = maxiters, error_norm = alg.error_norm)
+                        maxevals = maxiters, error_norm = alg.error_norm
+                    )
                 end
             else
                 if alg isa CubatureJLh
                     val_,
-                    err = Cubature.hcubature_v(fdim, _f, lb, ub;
+                        err = Cubature.hcubature_v(
+                        fdim, _f, lb, ub;
                         reltol = reltol, abstol = abstol,
-                        maxevals = maxiters, error_norm = alg.error_norm)
+                        maxevals = maxiters, error_norm = alg.error_norm
+                    )
                 else
                     val_,
-                    err = Cubature.pcubature_v(fdim, _f, lb, ub;
+                        err = Cubature.pcubature_v(
+                        fdim, _f, lb, ub;
                         reltol = reltol, abstol = abstol,
-                        maxevals = maxiters, error_norm = alg.error_norm)
+                        maxevals = maxiters, error_norm = alg.error_norm
+                    )
                 end
             end
             val = reshape(val_, fsize...)
@@ -111,26 +129,34 @@ function Integrals.__solvebp_call(prob::IntegralProblem,
             if lb isa Number
                 if alg isa CubatureJLh
                     val,
-                    err = Cubature.hquadrature(_f, lb, ub;
+                        err = Cubature.hquadrature(
+                        _f, lb, ub;
                         reltol = reltol, abstol = abstol,
-                        maxevals = maxiters)
+                        maxevals = maxiters
+                    )
                 else
                     val,
-                    err = Cubature.pquadrature(_f, lb, ub;
+                        err = Cubature.pquadrature(
+                        _f, lb, ub;
                         reltol = reltol, abstol = abstol,
-                        maxevals = maxiters)
+                        maxevals = maxiters
+                    )
                 end
             else
                 if alg isa CubatureJLh
                     val,
-                    err = Cubature.hcubature(_f, lb, ub;
+                        err = Cubature.hcubature(
+                        _f, lb, ub;
                         reltol = reltol, abstol = abstol,
-                        maxevals = maxiters)
+                        maxevals = maxiters
+                    )
                 else
                     val,
-                    err = Cubature.pcubature(_f, lb, ub;
+                        err = Cubature.pcubature(
+                        _f, lb, ub;
                         reltol = reltol, abstol = abstol,
-                        maxevals = maxiters)
+                        maxevals = maxiters
+                    )
                 end
             end
         elseif prototype isa AbstractArray
@@ -146,26 +172,34 @@ function Integrals.__solvebp_call(prob::IntegralProblem,
             if mid isa Number
                 if alg isa CubatureJLh
                     val_,
-                    err = Cubature.hquadrature(fdim, _f, lb, ub;
+                        err = Cubature.hquadrature(
+                        fdim, _f, lb, ub;
                         reltol = reltol, abstol = abstol,
-                        maxevals = maxiters, error_norm = alg.error_norm)
+                        maxevals = maxiters, error_norm = alg.error_norm
+                    )
                 else
                     val_,
-                    err = Cubature.pquadrature(fdim, _f, lb, ub;
+                        err = Cubature.pquadrature(
+                        fdim, _f, lb, ub;
                         reltol = reltol, abstol = abstol,
-                        maxevals = maxiters, error_norm = alg.error_norm)
+                        maxevals = maxiters, error_norm = alg.error_norm
+                    )
                 end
             else
                 if alg isa CubatureJLh
                     val_,
-                    err = Cubature.hcubature(fdim, _f, lb, ub;
+                        err = Cubature.hcubature(
+                        fdim, _f, lb, ub;
                         reltol = reltol, abstol = abstol,
-                        maxevals = maxiters, error_norm = alg.error_norm)
+                        maxevals = maxiters, error_norm = alg.error_norm
+                    )
                 else
                     val_,
-                    err = Cubature.pcubature(fdim, _f, lb, ub;
+                        err = Cubature.pcubature(
+                        fdim, _f, lb, ub;
                         reltol = reltol, abstol = abstol,
-                        maxevals = maxiters, error_norm = alg.error_norm)
+                        maxevals = maxiters, error_norm = alg.error_norm
+                    )
                 end
             end
             val = reshape(val_, fsize)
@@ -173,7 +207,7 @@ function Integrals.__solvebp_call(prob::IntegralProblem,
             error("IntegralFunctions must be scalars or arrays for Cubature.jl")
         end
     end
-    SciMLBase.build_solution(prob, alg, val, err, retcode = ReturnCode.Success)
+    return SciMLBase.build_solution(prob, alg, val, err, retcode = ReturnCode.Success)
 end
 
 end

--- a/ext/IntegralsFastGaussQuadratureExt.jl
+++ b/ext/IntegralsFastGaussQuadratureExt.jl
@@ -30,10 +30,12 @@ function composite_gauss_legendre(f::F, p, lb, ub, nodes, weights, subintervals)
     return I
 end
 
-function Integrals.__solvebp_call(prob::IntegralProblem, alg::Integrals.GaussLegendre{C},
+function Integrals.__solvebp_call(
+        prob::IntegralProblem, alg::Integrals.GaussLegendre{C},
         sensealg, domain, p;
         reltol = nothing, abstol = nothing,
-        maxiters = nothing) where {C}
+        maxiters = nothing
+    ) where {C}
     if !all(isone ∘ length, domain)
         error("GaussLegendre only accepts one-dimensional quadrature problems.")
     end
@@ -41,13 +43,17 @@ function Integrals.__solvebp_call(prob::IntegralProblem, alg::Integrals.GaussLeg
     @assert !isinplace(prob)
     lb, ub = map(only, domain)
     if C
-        val = composite_gauss_legendre(prob.f, prob.p, lb, ub,
-            alg.nodes, alg.weights, alg.subintervals)
+        val = composite_gauss_legendre(
+            prob.f, prob.p, lb, ub,
+            alg.nodes, alg.weights, alg.subintervals
+        )
     else
-        val = gauss_legendre(prob.f, prob.p, lb, ub,
-            alg.nodes, alg.weights)
+        val = gauss_legendre(
+            prob.f, prob.p, lb, ub,
+            alg.nodes, alg.weights
+        )
     end
     err = nothing
-    SciMLBase.build_solution(prob, alg, val, err, retcode = ReturnCode.Success)
+    return SciMLBase.build_solution(prob, alg, val, err, retcode = ReturnCode.Success)
 end
 end

--- a/ext/IntegralsMCIntegrationExt.jl
+++ b/ext/IntegralsMCIntegrationExt.jl
@@ -5,15 +5,17 @@ using MCIntegration, Integrals
 _oftype(::Number, x) = only(x)
 _oftype(y, x) = oftype(y, x)
 
-function Integrals.__solvebp_call(prob::IntegralProblem, alg::VEGASMC, sensealg, domain, p;
-        reltol = nothing, abstol = nothing, maxiters = 1000)
+function Integrals.__solvebp_call(
+        prob::IntegralProblem, alg::VEGASMC, sensealg, domain, p;
+        reltol = nothing, abstol = nothing, maxiters = 1000
+    )
     lb, ub = domain
     mid = (lb + ub) / 2
     tmp = vec(collect(mid))
     var = Continuous(vec([tuple(a, b) for (a, b) in zip(lb, ub)]))
 
     f = prob.f
-    if f isa BatchIntegralFunction
+    return if f isa BatchIntegralFunction
         error("VEGASMC doesn't support batching. See https://github.com/numericalEFT/MCIntegration.jl/issues/29")
     else
         prototype = Integrals.get_prototype(prob)
@@ -39,18 +41,22 @@ function Integrals.__solvebp_call(prob::IntegralProblem, alg::VEGASMC, sensealg,
             end
         end
         dof = ones(Int, length(prototype)) # each composite Continuous var gets 1 dof
-        res = integrate(_f; var, dof, inplace = isinplace(prob), type = eltype(prototype),
-            solver = :vegasmc, niter = maxiters, verbose = -2, print = -2, alg.kws...)
+        res = integrate(
+            _f; var, dof, inplace = isinplace(prob), type = eltype(prototype),
+            solver = :vegasmc, niter = maxiters, verbose = -2, print = -2, alg.kws...
+        )
         # the package itself is not type-stable
         out::typeof(prototype), err::typeof(prototype),
-        chi2 = if prototype isa Number
+            chi2 = if prototype isa Number
             map(only, (res.mean, res.stdev, res.chi2))
         else
             map(a -> reshape(a, size(prototype)), (res.mean, res.stdev, res.chi2))
         end
         chi::typeof(prototype) = map(sqrt, chi2)
-        SciMLBase.build_solution(prob, alg, out, err, chi = chi,
-            retcode = ReturnCode.Success)
+        SciMLBase.build_solution(
+            prob, alg, out, err, chi = chi,
+            retcode = ReturnCode.Success
+        )
     end
 end
 

--- a/ext/IntegralsZygoteExt.jl
+++ b/ext/IntegralsZygoteExt.jl
@@ -24,7 +24,8 @@ function ChainRulesCore.rrule(::Type{<:IntegralProblem}, f, domain, p; kwargs...
 end
 
 function ChainRulesCore.rrule(
-        ::Type{IntegralProblem{iip}}, f, domain, p; kwargs...) where {iip}
+        ::Type{IntegralProblem{iip}}, f, domain, p; kwargs...
+    ) where {iip}
     prob = IntegralProblem{iip}(f, domain, p; kwargs...)
     function IntegralProblem_iip_pullback(Δ)
         ddomain = hasproperty(Δ, :domain) ? Δ.domain : NoTangent()
@@ -36,12 +37,13 @@ end
 
 # TODO move this adjoint to SciMLBase
 function ChainRulesCore.rrule(
-        ::typeof(SciMLBase.build_solution), prob::IntegralProblem, alg, u, resid; kwargs...)
+        ::typeof(SciMLBase.build_solution), prob::IntegralProblem, alg, u, resid; kwargs...
+    )
     function build_integral_solution_pullback(Δ)
         return NoTangent(), NoTangent(), NoTangent(), Δ, NoTangent()
     end
     return SciMLBase.build_solution(prob, alg, u, resid; kwargs...),
-    build_integral_solution_pullback
+        build_integral_solution_pullback
 end
 
 function ChainRulesCore.rrule(::typeof(Integrals._evaluate!), f, y, u, p)
@@ -50,7 +52,7 @@ function ChainRulesCore.rrule(::typeof(Integrals._evaluate!), f, y, u, p)
         f(b, u, p)
         return copy(b)
     end
-    out, Δ -> (NoTangent(), NoTangent(), back(Δ)...)
+    return out, Δ -> (NoTangent(), NoTangent(), back(Δ)...)
 end
 
 function ChainRulesCore.rrule(::typeof(Integrals.u2t), lb, ub)
@@ -63,8 +65,10 @@ function ChainRulesCore.rrule(::typeof(Integrals.u2t), lb, ub)
     return out, u2t_pullback
 end
 
-Zygote.@adjoint function Zygote.literal_getproperty(sol::SciMLBase.IntegralSolution,
-        ::Val{:u})
+Zygote.@adjoint function Zygote.literal_getproperty(
+        sol::SciMLBase.IntegralSolution,
+        ::Val{:u}
+    )
     sol.u, Δ -> (SciMLBase.build_solution(sol.prob, sol.alg, Δ, sol.resid),)
 end
 end

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -65,7 +65,7 @@ struct HCubatureJL{F, B} <: SciMLBase.AbstractIntegralAlgorithm
     buffer::B
 end
 function HCubatureJL(; initdiv = 1, norm = norm, buffer = nothing)
-    HCubatureJL(initdiv, norm, buffer)
+    return HCubatureJL(initdiv, norm, buffer)
 end
 
 """
@@ -105,7 +105,7 @@ struct VEGAS{S} <: SciMLBase.AbstractIntegralAlgorithm
     seed::S
 end
 function VEGAS(; nbins = 100, ncalls = 1000, debug = false, seed = nothing)
-    VEGAS(nbins, ncalls, debug, seed)
+    return VEGAS(nbins, ncalls, debug, seed)
 end
 
 """

--- a/src/algorithms_extension.jl
+++ b/src/algorithms_extension.jl
@@ -103,7 +103,7 @@ publisher={ACM New York, NY, USA}
 ```
 """
 struct CubaDivonne{R1, R2, R3, R4} <:
-       AbstractCubaAlgorithm where {R1 <: Real, R2 <: Real, R3 <: Real, R4 <: Real}
+    AbstractCubaAlgorithm where {R1 <: Real, R2 <: Real, R3 <: Real, R4 <: Real}
     flags::Int
     seed::Int
     minevals::Int
@@ -145,29 +145,37 @@ struct CubaCuhre <: AbstractCubaAlgorithm
     key::Int
 end
 
-function CubaVegas(; flags = 0, seed = 0, minevals = 0, nstart = 1000, nincrease = 500,
-        gridno = 0)
+function CubaVegas(;
+        flags = 0, seed = 0, minevals = 0, nstart = 1000, nincrease = 500,
+        gridno = 0
+    )
     isnothing(Base.get_extension(@__MODULE__, :IntegralsCubaExt)) &&
         error("CubaVegas requires `using Cuba`")
     return CubaVegas(flags, seed, minevals, nstart, nincrease, gridno)
 end
 
-function CubaSUAVE(; flags = 0, seed = 0, minevals = 0, nnew = 1000, nmin = 2,
-        flatness = 25.0)
+function CubaSUAVE(;
+        flags = 0, seed = 0, minevals = 0, nnew = 1000, nmin = 2,
+        flatness = 25.0
+    )
     isnothing(Base.get_extension(@__MODULE__, :IntegralsCubaExt)) &&
         error("CubaSUAVE requires `using Cuba`")
     return CubaSUAVE(flags, seed, minevals, nnew, nmin, flatness)
 end
 
-function CubaDivonne(; flags = 0, seed = 0, minevals = 0,
+function CubaDivonne(;
+        flags = 0, seed = 0, minevals = 0,
         key1 = 47, key2 = 1, key3 = 1, maxpass = 5, border = 0.0,
         maxchisq = 10.0, mindeviation = 0.25,
         xgiven = zeros(Cdouble, 0, 0),
-        nextra = 0, peakfinder = C_NULL)
+        nextra = 0, peakfinder = C_NULL
+    )
     isnothing(Base.get_extension(@__MODULE__, :IntegralsCubaExt)) &&
         error("CubaDivonne requires `using Cuba`")
-    return CubaDivonne(flags, seed, minevals, key1, key2, key3, maxpass, border, maxchisq,
-        mindeviation, xgiven, nextra, peakfinder)
+    return CubaDivonne(
+        flags, seed, minevals, key1, key2, key3, maxpass, border, maxchisq,
+        mindeviation, xgiven, nextra, peakfinder
+    )
 end
 
 function CubaCuhre(; flags = 0, minevals = 0, key = 0)
@@ -256,8 +264,10 @@ struct ArblibJL{O} <: AbstractIntegralCExtensionAlgorithm
     warn_on_no_convergence::Bool
     opts::O
 end
-function ArblibJL(; check_analytic = false, take_prec = false,
-        warn_on_no_convergence = false, opts = C_NULL)
+function ArblibJL(;
+        check_analytic = false, take_prec = false,
+        warn_on_no_convergence = false, opts = C_NULL
+    )
     isnothing(Base.get_extension(@__MODULE__, :IntegralsArblibExt)) &&
         error("ArblibJL requires `using Arblib`")
     return ArblibJL(check_analytic, take_prec, warn_on_no_convergence, opts)

--- a/src/algorithms_meta.jl
+++ b/src/algorithms_meta.jl
@@ -42,7 +42,7 @@ sol = solve(prob, alg)
 See also: [`transformation_if_inf`](@ref), [`transformation_tan_inf`](@ref), [`transformation_cot_inf`](@ref)
 """
 struct ChangeOfVariables{T, A <: SciMLBase.AbstractIntegralAlgorithm} <:
-       AbstractIntegralMetaAlgorithm
+    AbstractIntegralMetaAlgorithm
     fu2gv::T
     alg::A
 end

--- a/src/infinity_handling.jl
+++ b/src/infinity_handling.jl
@@ -18,7 +18,7 @@ end
 
 function substitute_f(f::IntegralFunction{false}, v2ujac, lb, ub)
     _f = f.f
-    IntegralFunction{false}(f.integrand_prototype) do v, p
+    return IntegralFunction{false}(f.integrand_prototype) do v, p
         u, jac = substitute_v(v2ujac, v, lb, ub)
         return _f(u, p) * jac
     end
@@ -27,7 +27,7 @@ function substitute_f(f::IntegralFunction{true}, v2ujac, lb, ub)
     _f = f.f
     prototype = similar(f.integrand_prototype)
     vol = prod((ub - lb) / 2) # just to get the type of the jacobian determinant
-    IntegralFunction{true}(prototype * vol) do y, v, p
+    return IntegralFunction{true}(prototype * vol) do y, v, p
         u, jac = substitute_v(v2ujac, v, lb, ub)
         _y = _evaluate!(_f, prototype, u, p)
         y .= _y .* jac
@@ -61,7 +61,7 @@ end
 
 function substitute_f(f::BatchIntegralFunction{false}, v2ujac, lb, ub)
     _f = f.f
-    BatchIntegralFunction{false}(f.integrand_prototype, max_batch = f.max_batch) do v, p
+    return BatchIntegralFunction{false}(f.integrand_prototype, max_batch = f.max_batch) do v, p
         u, jac = substitute_bv(v2ujac, v, lb, ub)
         y = _f(u, p)
         return y .* reshape(jac, ntuple(d -> d == ndims(y) ? length(jac) : 1, ndims(y)))
@@ -71,7 +71,7 @@ function substitute_f(f::BatchIntegralFunction{true}, v2ujac, lb, ub)
     _f = f.f
     prototype = similar(f.integrand_prototype)
     vol = prod((ub - lb) / 2) # just to get the type of the jacobian determinant
-    BatchIntegralFunction{true}(prototype * vol, max_batch = f.max_batch) do y, v, p
+    return BatchIntegralFunction{true}(prototype * vol, max_batch = f.max_batch) do y, v, p
         u, jac = substitute_bv(v2ujac, v, lb, ub)
         _prototype = similar(prototype, size(y))
         _y = _evaluate!(_f, _prototype, u, p)
@@ -109,7 +109,7 @@ end
 function t2ujac(t::Number, lb::Number, ub::Number)
     u = oneunit(eltype(lb))
     # apply correct units
-    if isinf(lb) && isinf(ub)
+    return if isinf(lb) && isinf(ub)
         den = inv(1 - t^2)
         t * den * u, (1 + t^2) * den^2 * u
     elseif isinf(lb)
@@ -190,7 +190,7 @@ end
 
 function t2ujac_tan(t::Number, lb::Number, ub::Number)
     u = oneunit(eltype(lb))
-    if isinf(lb) && isinf(ub)
+    return if isinf(lb) && isinf(ub)
         # Doubly-infinite: t ∈ [-1, 1] → u ∈ (-∞, ∞)
         # u = tan(πt/2), du/dt = (π/2) sec²(πt/2)
         halfpi = oftype(float(one(u)), π / 2)
@@ -291,7 +291,7 @@ end
 
 function t2ujac_cot(t::Number, lb::Number, ub::Number)
     u = oneunit(eltype(lb))
-    if isinf(lb) && isinf(ub)
+    return if isinf(lb) && isinf(ub)
         # For doubly-infinite, use the tan transformation
         # u = tan(πt/2), du/dt = (π/2) sec²(πt/2)
         halfpi = oftype(float(one(u)), π / 2)

--- a/src/quadrules.jl
+++ b/src/quadrules.jl
@@ -22,10 +22,12 @@ function init_cacheval(alg::QuadratureRule, ::IntegralProblem)
     return alg.q(alg.n)
 end
 
-function Integrals.__solvebp_call(cache::IntegralCache, alg::QuadratureRule,
+function Integrals.__solvebp_call(
+        cache::IntegralCache, alg::QuadratureRule,
         sensealg, domain, p;
         reltol = nothing, abstol = nothing,
-        maxiters = nothing)
+        maxiters = nothing
+    )
     prob = build_problem(cache)
     if isinplace(prob)
         error("QuadratureRule does not support inplace integrands.")
@@ -36,5 +38,5 @@ function Integrals.__solvebp_call(cache::IntegralCache, alg::QuadratureRule,
     val = evalrule(cache.f, cache.p, lb, ub, cache.cacheval...)
 
     err = nothing
-    SciMLBase.build_solution(prob, alg, val, err, retcode = ReturnCode.Success)
+    return SciMLBase.build_solution(prob, alg, val, err, retcode = ReturnCode.Success)
 end

--- a/src/sampled.jl
+++ b/src/sampled.jl
@@ -33,9 +33,9 @@ Implementations must have:
 """
 abstract type NonuniformWeights <: AbstractWeights end
 @inline Base.iterate(w::NonuniformWeights) = (0 == length(w.x)) ? nothing :
-                                             (w[firstindex(w.x)], firstindex(w.x))
+    (w[firstindex(w.x)], firstindex(w.x))
 @inline Base.iterate(w::NonuniformWeights, i) = (i == lastindex(w.x)) ? nothing :
-                                                (w[i + 1], i + 1)
+    (w[i + 1], i + 1)
 Base.length(w::NonuniformWeights) = length(w.x)
 Base.eltype(w::NonuniformWeights) = eltype(w.x)
 Base.size(w::NonuniformWeights) = (length(w),)
@@ -110,14 +110,18 @@ end
 
 # can be reused for other sampled rules, which should implement find_weights(x, alg)
 
-function init_cacheval(alg::SciMLBase.AbstractIntegralAlgorithm,
-        prob::SampledIntegralProblem)
-    find_weights(prob.x, alg)
+function init_cacheval(
+        alg::SciMLBase.AbstractIntegralAlgorithm,
+        prob::SampledIntegralProblem
+    )
+    return find_weights(prob.x, alg)
 end
 
-function __solvebp_call(cache::SampledIntegralCache,
+function __solvebp_call(
+        cache::SampledIntegralCache,
         alg::SciMLBase.AbstractIntegralAlgorithm;
-        kwargs...)
+        kwargs...
+    )
     dim = dimension(cache.dim)
     err = nothing
     data = cache.y

--- a/src/simpsons.jl
+++ b/src/simpsons.jl
@@ -14,7 +14,7 @@ struct SimpsonUniformWeights{T} <: UniformWeights
 end
 
 @inline function Base.getindex(w::SimpsonUniformWeights, i)
-    # evenly spaced simpson's 1/3, 3/8 rule 
+    # evenly spaced simpson's 1/3, 3/8 rule
     h = w.h
     n = w.n
     (i == 1 || i == n) && return 17h / 48
@@ -43,38 +43,42 @@ end
     checkbounds(w.x, i)
     x = w.x
     j = i - firstindex(x)
-    @assert length(w.x)>2 "The length of the grid must exceed 2 for simpsons rule."
+    @assert length(w.x) > 2 "The length of the grid must exceed 2 for simpsons rule."
     i == firstindex(x) && return (x[begin + 2] - x[begin + 0]) / 6 *
-           (2 - (x[begin + 2] - x[begin + 1]) / (x[begin + 1] - x[begin + 0]))
+        (2 - (x[begin + 2] - x[begin + 1]) / (x[begin + 1] - x[begin + 0]))
 
     if isodd(length(x)) # even number of subintervals
         i == lastindex(x) && return (x[end] - x[end - 2]) / 6 *
-               (2 - (x[end - 1] - x[end - 2]) / (x[end] - x[end - 1]))
+            (2 - (x[end - 1] - x[end - 2]) / (x[end] - x[end - 1]))
     else # odd number of subintervals, we add additional terms
         i == lastindex(x) && return (x[end] - x[end - 1]) *
-               (2 * (x[end] - x[end - 1]) + 3 * (x[end - 1] - x[end - 2])) /
-               (x[end] - x[end - 2]) / 6
+            (2 * (x[end] - x[end - 1]) + 3 * (x[end - 1] - x[end - 2])) /
+            (x[end] - x[end - 2]) / 6
         i == lastindex(x) - 1 && return (x[end - 1] - x[end - 3]) / 6 *
-               (2 - (x[end - 2] - x[end - 3]) / (x[end - 1] - x[end - 2])) +
-               (x[end] - x[end - 1]) *
-               ((x[end] - x[end - 1]) + 3 * (x[end - 1] - x[end - 2])) /
-               (x[end - 1] - x[end - 2]) / 6
+            (2 - (x[end - 2] - x[end - 3]) / (x[end - 1] - x[end - 2])) +
+            (x[end] - x[end - 1]) *
+            ((x[end] - x[end - 1]) + 3 * (x[end - 1] - x[end - 2])) /
+            (x[end - 1] - x[end - 2]) / 6
         i == lastindex(x) - 2 &&
             return (x[end - 1] - x[end - 3])^3 / (x[end - 2] - x[end - 3]) /
-                   (x[end - 1] - x[end - 2]) / 6 -
-                   (x[end] - x[end - 1])^3 / (x[end - 1] - x[end - 2]) /
-                   (x[end] - x[end - 2]) / 6
+            (x[end - 1] - x[end - 2]) / 6 -
+            (x[end] - x[end - 1])^3 / (x[end - 1] - x[end - 2]) /
+            (x[end] - x[end - 2]) / 6
     end
     isodd(j) &&
         return (x[begin + j + 1] - x[begin + j - 1])^3 / (x[begin + j] - x[begin + j - 1]) /
-               (x[begin + j + 1] - x[begin + j]) / 6
-    iseven(j) &&
+        (x[begin + j + 1] - x[begin + j]) / 6
+    return iseven(j) &&
         return (x[begin + j] - x[begin + j - 2]) / 6 *
-               (2 -
-                (x[begin + j - 1] - x[begin + j - 2]) / (x[begin + j] - x[begin + j - 1])) +
-               (x[begin + j + 2] - x[begin + j]) / 6 *
-               (2 -
-                (x[begin + j + 2] - x[begin + j + 1]) / (x[begin + j + 1] - x[begin + j]))
+        (
+        2 -
+            (x[begin + j - 1] - x[begin + j - 2]) / (x[begin + j] - x[begin + j - 1])
+    ) +
+        (x[begin + j + 2] - x[begin + j]) / 6 *
+        (
+        2 -
+            (x[begin + j + 2] - x[begin + j + 1]) / (x[begin + j + 1] - x[begin + j])
+    )
 end
 
 function find_weights(x::AbstractVector, ::SimpsonsRule)

--- a/src/trapezoidal.jl
+++ b/src/trapezoidal.jl
@@ -13,9 +13,11 @@ struct TrapezoidalUniformWeights{T} <: UniformWeights
     h::T
 end
 
-@inline Base.getindex(w::TrapezoidalUniformWeights, i) = ifelse((i == 1) || (i == w.n),
+@inline Base.getindex(w::TrapezoidalUniformWeights, i) = ifelse(
+    (i == 1) || (i == w.n),
     w.h / 2,
-    w.h)
+    w.h
+)
 
 """
     TrapezoidalNonuniformWeights{X <: AbstractArray} <: NonuniformWeights

--- a/test/alt_transformation_tests.jl
+++ b/test/alt_transformation_tests.jl
@@ -1,7 +1,7 @@
 using Integrals, Test
 
-reltol = 1e-6
-abstol = 1e-6
+reltol = 1.0e-6
+abstol = 1.0e-6
 
 @testset "Alternative Infinity Transformations" begin
     @testset "transformation_tan_inf" begin
@@ -10,37 +10,37 @@ abstol = 1e-6
         prob = IntegralProblem(f_gaussian, (-Inf, Inf))
         alg = ChangeOfVariables(transformation_tan_inf, QuadGKJL())
         sol = solve(prob, alg; reltol, abstol)
-        @test isapprox(sol.u, sqrt(π), rtol = 1e-5)
+        @test isapprox(sol.u, sqrt(π), rtol = 1.0e-5)
 
         # Test Lorentzian: ∫_{-∞}^{∞} 1/(1+x²) dx = π
         f_lorentz = (x, p) -> 1 / (1 + x^2)
         prob = IntegralProblem(f_lorentz, (-Inf, Inf))
         sol = solve(prob, alg; reltol, abstol)
-        @test isapprox(sol.u, π, rtol = 1e-5)
+        @test isapprox(sol.u, π, rtol = 1.0e-5)
 
         # Test semi-infinite upper: ∫_0^{∞} exp(-x) dx = 1
         f_exp = (x, p) -> exp(-x)
         prob = IntegralProblem(f_exp, (0.0, Inf))
         sol = solve(prob, alg; reltol, abstol)
-        @test isapprox(sol.u, 1.0, rtol = 1e-4)
+        @test isapprox(sol.u, 1.0, rtol = 1.0e-4)
 
         # Test semi-infinite lower: ∫_{-∞}^0 exp(x) dx = 1
         f_exp_neg = (x, p) -> exp(x)
         prob = IntegralProblem(f_exp_neg, (-Inf, 0.0))
         sol = solve(prob, alg; reltol, abstol)
-        @test isapprox(sol.u, 1.0, rtol = 1e-4)
+        @test isapprox(sol.u, 1.0, rtol = 1.0e-4)
 
         # Test semi-infinite with non-zero bound: ∫_2^{∞} 1/((x-2)² + 1) dx = π/2
         f_shifted_lorentz = (x, p) -> 1 / ((x - 2)^2 + 1)
         prob = IntegralProblem(f_shifted_lorentz, (2.0, Inf))
         sol = solve(prob, alg; reltol, abstol)
-        @test isapprox(sol.u, π / 2, rtol = 1e-4)
+        @test isapprox(sol.u, π / 2, rtol = 1.0e-4)
 
         # Test with negative semi-infinite bound: ∫_{-∞}^{-1} exp(x) dx = exp(-1)
         f_exp_shifted = (x, p) -> exp(x)
         prob = IntegralProblem(f_exp_shifted, (-Inf, -1.0))
         sol = solve(prob, alg; reltol, abstol)
-        @test isapprox(sol.u, exp(-1), rtol = 1e-4)
+        @test isapprox(sol.u, exp(-1), rtol = 1.0e-4)
     end
 
     @testset "transformation_cot_inf" begin
@@ -49,24 +49,24 @@ abstol = 1e-6
         prob = IntegralProblem(f_gaussian, (-Inf, Inf))
         alg = ChangeOfVariables(transformation_cot_inf, QuadGKJL())
         sol = solve(prob, alg; reltol, abstol)
-        @test isapprox(sol.u, sqrt(π), rtol = 1e-5)
+        @test isapprox(sol.u, sqrt(π), rtol = 1.0e-5)
 
         # Test semi-infinite upper: ∫_0^{∞} exp(-x) dx = 1
         f_exp = (x, p) -> exp(-x)
         prob = IntegralProblem(f_exp, (0.0, Inf))
-        sol = solve(prob, alg; reltol = 1e-4, abstol = 1e-4)
-        @test isapprox(sol.u, 1.0, rtol = 1e-3)
+        sol = solve(prob, alg; reltol = 1.0e-4, abstol = 1.0e-4)
+        @test isapprox(sol.u, 1.0, rtol = 1.0e-3)
 
         # Test semi-infinite lower: ∫_{-∞}^0 exp(x) dx = 1
         f_exp_neg = (x, p) -> exp(x)
         prob = IntegralProblem(f_exp_neg, (-Inf, 0.0))
-        sol = solve(prob, alg; reltol = 1e-4, abstol = 1e-4)
-        @test isapprox(sol.u, 1.0, rtol = 1e-3)
+        sol = solve(prob, alg; reltol = 1.0e-4, abstol = 1.0e-4)
+        @test isapprox(sol.u, 1.0, rtol = 1.0e-3)
 
         # Test half Gaussian: ∫_0^{∞} exp(-x²) dx = √π/2
         prob = IntegralProblem(f_gaussian, (0.0, Inf))
-        sol = solve(prob, alg; reltol = 1e-4, abstol = 1e-4)
-        @test isapprox(sol.u, sqrt(π) / 2, rtol = 1e-3)
+        sol = solve(prob, alg; reltol = 1.0e-4, abstol = 1.0e-4)
+        @test isapprox(sol.u, sqrt(π) / 2, rtol = 1.0e-3)
     end
 
     @testset "Finite domains unchanged" begin
@@ -75,14 +75,18 @@ abstol = 1e-6
         prob = IntegralProblem(f, (0.0, 1.0))
 
         sol_default = solve(prob, QuadGKJL(); reltol, abstol)
-        sol_tan = solve(prob, ChangeOfVariables(transformation_tan_inf, QuadGKJL());
-            reltol, abstol)
-        sol_cot = solve(prob, ChangeOfVariables(transformation_cot_inf, QuadGKJL());
-            reltol, abstol)
+        sol_tan = solve(
+            prob, ChangeOfVariables(transformation_tan_inf, QuadGKJL());
+            reltol, abstol
+        )
+        sol_cot = solve(
+            prob, ChangeOfVariables(transformation_cot_inf, QuadGKJL());
+            reltol, abstol
+        )
 
-        @test isapprox(sol_default.u, 1 / 3, rtol = 1e-8)
-        @test isapprox(sol_tan.u, 1 / 3, rtol = 1e-8)
-        @test isapprox(sol_cot.u, 1 / 3, rtol = 1e-8)
+        @test isapprox(sol_default.u, 1 / 3, rtol = 1.0e-8)
+        @test isapprox(sol_tan.u, 1 / 3, rtol = 1.0e-8)
+        @test isapprox(sol_cot.u, 1 / 3, rtol = 1.0e-8)
     end
 
     @testset "Flipped infinite limits" begin
@@ -93,7 +97,7 @@ abstol = 1e-6
         prob = IntegralProblem(f, (Inf, -Inf))
         alg = ChangeOfVariables(transformation_tan_inf, QuadGKJL())
         sol = solve(prob, alg; reltol, abstol)
-        @test isapprox(sol.u, -sqrt(π), rtol = 1e-5)
+        @test isapprox(sol.u, -sqrt(π), rtol = 1.0e-5)
     end
 
     @testset "Works with different algorithms" begin
@@ -103,7 +107,7 @@ abstol = 1e-6
         # Test with HCubatureJL
         alg_hcub = ChangeOfVariables(transformation_tan_inf, HCubatureJL())
         sol = solve(prob, alg_hcub; reltol, abstol)
-        @test isapprox(sol.u, sqrt(π), rtol = 1e-4)
+        @test isapprox(sol.u, sqrt(π), rtol = 1.0e-4)
     end
 
     @testset "ChangeOfVariables exported" begin

--- a/test/derivative_tests.jl
+++ b/test/derivative_tests.jl
@@ -1,4 +1,4 @@
-using Integrals, Mooncake, Zygote, FiniteDiff, ForwardDiff#, SciMLSensitivity
+using Integrals, Mooncake, Zygote, FiniteDiff, ForwardDiff #, SciMLSensitivity
 using Cuba, Cubature
 using FastGaussQuadrature
 using Test
@@ -6,28 +6,45 @@ using Test
 max_dim_test = 2
 max_nout_test = 2
 
-reltol = 1e-3
-abstol = 1e-3
+reltol = 1.0e-3
+abstol = 1.0e-3
 
 alg_req = Dict(
-    QuadratureRule(gausslegendre,
-        n = 50) => (
+    QuadratureRule(
+        gausslegendre,
+        n = 50
+    ) => (
         nout = Inf, min_dim = 1, max_dim = 1, allows_batch = false,
-        allows_iip = false),
-    GaussLegendre(n = 50) => (nout = Inf, min_dim = 1, max_dim = 1, allows_batch = false,
-        allows_iip = false),
-    GaussLegendre(n = 50,
-        subintervals = 3) => (
+        allows_iip = false,
+    ),
+    GaussLegendre(n = 50) => (
         nout = Inf, min_dim = 1, max_dim = 1, allows_batch = false,
-        allows_iip = false),
-    QuadGKJL() => (nout = Inf, allows_batch = true, min_dim = 1, max_dim = 1,
-        allows_iip = true),
-    HCubatureJL() => (nout = Inf, allows_batch = false, min_dim = 1,
-        max_dim = Inf, allows_iip = true),
-    CubatureJLh() => (nout = Inf, allows_batch = true, min_dim = 1,
-        max_dim = Inf, allows_iip = true),
-    CubatureJLp() => (nout = Inf, allows_batch = true, min_dim = 1,
-        max_dim = Inf, allows_iip = true))
+        allows_iip = false,
+    ),
+    GaussLegendre(
+        n = 50,
+        subintervals = 3
+    ) => (
+        nout = Inf, min_dim = 1, max_dim = 1, allows_batch = false,
+        allows_iip = false,
+    ),
+    QuadGKJL() => (
+        nout = Inf, allows_batch = true, min_dim = 1, max_dim = 1,
+        allows_iip = true,
+    ),
+    HCubatureJL() => (
+        nout = Inf, allows_batch = false, min_dim = 1,
+        max_dim = Inf, allows_iip = true,
+    ),
+    CubatureJLh() => (
+        nout = Inf, allows_batch = true, min_dim = 1,
+        max_dim = Inf, allows_iip = true,
+    ),
+    CubatureJLp() => (
+        nout = Inf, allows_batch = true, min_dim = 1,
+        max_dim = Inf, allows_iip = true,
+    )
+)
 # VEGAS() => (nout = 1, allows_batch = true, min_dim = 2, max_dim = Inf,
 # allows_iip = true),
 # CubaVegas() => (nout = Inf, allows_batch = true, min_dim = 1, max_dim = Inf,
@@ -47,7 +64,7 @@ integrands = (
 # function to turn the output into a scalar / test different tangent types
 scalarize_solution = (
     sol -> sin(sum(sol)),
-    sol -> sin(sol[1])
+    sol -> sin(sol[1]),
 )
 
 # we will be able to use broadcasting for this after https://github.com/FluxML/Zygote.jl/pull/1488
@@ -94,7 +111,7 @@ Mooncake.rdata_type(::Type{Scalar{T}}) where {T <: Real} = Mooncake.rdata_type(T
 # p can't be either without both prs
 function batch_helper(f, x, p)
     t = f(zero(eltype(x)), zero(eltype(eltype(p))))
-    typeof(t).([f(y, q) for q in p, y in eachslice(x; dims = ndims(x))])
+    return typeof(t).([f(y, q) for q in p, y in eachslice(x; dims = ndims(x))])
 end
 
 function batch_helper!(f, y, x, p)
@@ -106,13 +123,14 @@ end
 do_tests = function (; f, scalarize, lb, ub, p, alg, abstol, reltol)
     testf = function (lb, ub, p)
         prob = IntegralProblem(f, (lb, ub), p)
-        scalarize(solve(prob, alg; reltol, abstol))
+        return scalarize(solve(prob, alg; reltol, abstol))
     end
     testf(lb, ub, p)
 
     dlb1, dub1,
-    dp1 = Zygote.gradient(
-        testf, lb, ub, p isa Number && f isa BatchIntegralFunction ? Scalar(p) : p)
+        dp1 = Zygote.gradient(
+        testf, lb, ub, p isa Number && f isa BatchIntegralFunction ? Scalar(p) : p
+    )
 
     f_lb = lb -> testf(lb, ub, p)
     f_ub = ub -> testf(lb, ub, p)
@@ -124,16 +142,16 @@ do_tests = function (; f, scalarize, lb, ub, p, alg, abstol, reltol)
     dub2 = getproperty(FiniteDiff, Symbol(:finite_difference_, dub))(f_ub, ub)
 
     if lb isa Number
-        @test dlb1≈dlb2 atol=abstol rtol=reltol
-        @test dub1≈dub2 atol=abstol rtol=reltol
+        @test dlb1 ≈ dlb2 atol = abstol rtol = reltol
+        @test dub1 ≈ dub2 atol = abstol rtol = reltol
     else # TODO: implement multivariate limit derivatives in ZygoteExt
-        @test_broken dlb1≈dlb2 atol=abstol rtol=reltol
-        @test_broken dub1≈dub2 atol=abstol rtol=reltol
+        @test_broken dlb1 ≈ dlb2 atol = abstol rtol = reltol
+        @test_broken dub1 ≈ dub2 atol = abstol rtol = reltol
     end
 
     # TODO: implement limit derivatives in ForwardDiffExt
-    @test_broken dlb2≈getproperty(ForwardDiff, dlb)(dfdlb, lb) atol=abstol rtol=reltol
-    @test_broken dub2≈getproperty(ForwardDiff, dub)(dfdub, ub) atol=abstol rtol=reltol
+    @test_broken dlb2 ≈ getproperty(ForwardDiff, dlb)(dfdlb, lb) atol = abstol rtol = reltol
+    @test_broken dub2 ≈ getproperty(ForwardDiff, dub)(dfdub, ub) atol = abstol rtol = reltol
 
     f_p = p -> testf(lb, ub, p)
 
@@ -142,8 +160,8 @@ do_tests = function (; f, scalarize, lb, ub, p, alg, abstol, reltol)
     dp2 = getproperty(FiniteDiff, Symbol(:finite_difference_, dp))(f_p, p)
     dp3 = getproperty(ForwardDiff, dp)(f_p, p)
 
-    @test dp1≈dp2 atol=abstol rtol=reltol
-    @test dp2≈dp3 atol=abstol rtol=reltol
+    @test dp1 ≈ dp2 atol = abstol rtol = reltol
+    @test dp2 ≈ dp3 atol = abstol rtol = reltol
 
     return
 end
@@ -152,20 +170,26 @@ end
 do_tests_mooncake = function (; f, scalarize, lb, ub, p, alg, abstol, reltol)
     testf = function (lb, ub, p)
         prob = IntegralProblem(f, (lb, ub), p)
-        scalarize(solve(prob,
-            alg;
-            reltol,
-            abstol,
-            sensealg = Integrals.ReCallVJP{Integrals.MooncakeVJP}(Integrals.MooncakeVJP())))
+        return scalarize(
+            solve(
+                prob,
+                alg;
+                reltol,
+                abstol,
+                sensealg = Integrals.ReCallVJP{Integrals.MooncakeVJP}(Integrals.MooncakeVJP())
+            )
+        )
     end
     sol_fp = testf(lb, ub, p)
 
     # sensealg when non zygoet?
     cache = Mooncake.prepare_gradient_cache(
-        testf, lb, ub, p isa Number && f isa BatchIntegralFunction ? Scalar(p) : p)
+        testf, lb, ub, p isa Number && f isa BatchIntegralFunction ? Scalar(p) : p
+    )
     forwpassval,
-    gradients = Mooncake.value_and_gradient!!(
-        cache, testf, lb, ub, p isa Number && f isa BatchIntegralFunction ? Scalar(p) : p)
+        gradients = Mooncake.value_and_gradient!!(
+        cache, testf, lb, ub, p isa Number && f isa BatchIntegralFunction ? Scalar(p) : p
+    )
 
     @test forwpassval == sol_fp
 
@@ -179,11 +203,11 @@ do_tests_mooncake = function (; f, scalarize, lb, ub, p, alg, abstol, reltol)
     dub2 = getproperty(FiniteDiff, Symbol(:finite_difference_, dub))(f_ub, ub)
 
     if lb isa Number
-        @test gradients[2]≈dlb2 atol=abstol rtol=reltol
-        @test gradients[3]≈dub2 atol=abstol rtol=reltol
+        @test gradients[2] ≈ dlb2 atol = abstol rtol = reltol
+        @test gradients[3] ≈ dub2 atol = abstol rtol = reltol
     else # TODO: implement multivariate limit derivatives in MooncakeExt
-        @test_broken gradients[2]≈dlb2 atol=abstol rtol=reltol
-        @test_broken gradients[3]≈dub2 atol=abstol rtol=reltol
+        @test_broken gradients[2] ≈ dlb2 atol = abstol rtol = reltol
+        @test_broken gradients[3] ≈ dub2 atol = abstol rtol = reltol
     end
 
     f_p = p -> testf(lb, ub, p)
@@ -192,232 +216,261 @@ do_tests_mooncake = function (; f, scalarize, lb, ub, p, alg, abstol, reltol)
     dp2 = getproperty(FiniteDiff, Symbol(:finite_difference_, dp))(f_p, p)
     dp3 = getproperty(ForwardDiff, dp)(f_p, p)
 
-    @test dp2≈dp3 atol=abstol rtol=reltol
+    @test dp2 ≈ dp3 atol = abstol rtol = reltol
 
     # test Mooncake for parameter p
-    @test gradients[4]≈dp2 atol=abstol rtol=reltol
-    @test dp2≈dp3 atol=abstol rtol=reltol
+    @test gradients[4] ≈ dp2 atol = abstol rtol = reltol
+    @test dp2 ≈ dp3 atol = abstol rtol = reltol
 
     return
 end
 
 ### One Dimensional
 for (alg, req) in pairs(alg_req), (j, f) in enumerate(integrands),
-    (i, scalarize) in enumerate(scalarize_solution)
+        (i, scalarize) in enumerate(scalarize_solution)
     req.nout > 1 || continue
     req.min_dim <= 1 || continue
 
-    @info "One-dimensional, scalar, oop derivative test" alg=nameof(typeof(alg)) integrand=j scalarize=i
+    @info "One-dimensional, scalar, oop derivative test" alg = nameof(typeof(alg)) integrand = j scalarize = i
     do_tests(; f, scalarize, lb = 1.0, ub = 3.0, p = 2.0, alg, abstol, reltol)
     do_tests_mooncake(; f, scalarize, lb = 1.0, ub = 3.0, p = 2.0, alg, abstol, reltol)
 end
 
 ## One-dimensional nout
 for (alg, req) in pairs(alg_req), (j, f) in enumerate(integrands),
-    (i, scalarize) in enumerate(scalarize_solution), nout in 1:max_nout_test
+        (i, scalarize) in enumerate(scalarize_solution), nout in 1:max_nout_test
     req.nout > 1 || continue
     req.min_dim <= 1 || continue
 
-    @info "One-dimensional, multivariate, oop derivative test" alg=nameof(typeof(alg)) integrand=j scalarize=i nout
+    @info "One-dimensional, multivariate, oop derivative test" alg = nameof(typeof(alg)) integrand = j scalarize = i nout
     do_tests(;
-        f, scalarize, lb = 1.0, ub = 3.0, p = [2.0i for i in 1:nout], alg, abstol, reltol)
+        f, scalarize, lb = 1.0, ub = 3.0, p = [2.0i for i in 1:nout], alg, abstol, reltol
+    )
     do_tests_mooncake(;
-        f, scalarize, lb = 1.0, ub = 3.0, p = [2.0i for i in 1:nout], alg, abstol, reltol)
+        f, scalarize, lb = 1.0, ub = 3.0, p = [2.0i for i in 1:nout], alg, abstol, reltol
+    )
 end
 
 ### N-dimensional
 for (alg, req) in pairs(alg_req), (j, f) in enumerate(integrands),
-    (i, scalarize) in enumerate(scalarize_solution), dim in 1:max_dim_test
+        (i, scalarize) in enumerate(scalarize_solution), dim in 1:max_dim_test
     req.nout > 1 || continue
     req.min_dim <= dim <= req.max_dim || continue
 
-    @info "Multi-dimensional, scalar, oop derivative test" alg=nameof(typeof(alg)) integrand=j scalarize=i dim
+    @info "Multi-dimensional, scalar, oop derivative test" alg = nameof(typeof(alg)) integrand = j scalarize = i dim
     do_tests(; f, scalarize, lb = ones(dim), ub = 3ones(dim), p = 2.0, alg, abstol, reltol)
     do_tests_mooncake(;
-        f, scalarize, lb = ones(dim), ub = 3ones(dim), p = 2.0, alg, abstol, reltol)
+        f, scalarize, lb = ones(dim), ub = 3ones(dim), p = 2.0, alg, abstol, reltol
+    )
 end
 
 ### N-dimensional nout
 for (alg, req) in pairs(alg_req), (j, f) in enumerate(integrands),
-    (i, scalarize) in enumerate(scalarize_solution), dim in 1:max_dim_test,
-    nout in 1:max_nout_test
+        (i, scalarize) in enumerate(scalarize_solution), dim in 1:max_dim_test,
+        nout in 1:max_nout_test
     req.nout > 1 || continue
     req.min_dim <= dim <= req.max_dim || continue
 
-    @info "Multi-dimensional, multivariate, oop derivative test" alg=nameof(typeof(alg)) integrand=j scalarize=i dim nout
-    do_tests(; f, scalarize, lb = ones(dim), ub = 3ones(dim),
-        p = [2.0i for i in 1:nout], alg, abstol, reltol)
-    do_tests_mooncake(; f, scalarize, lb = ones(dim), ub = 3ones(dim),
-        p = [2.0i for i in 1:nout], alg, abstol, reltol)
+    @info "Multi-dimensional, multivariate, oop derivative test" alg = nameof(typeof(alg)) integrand = j scalarize = i dim nout
+    do_tests(;
+        f, scalarize, lb = ones(dim), ub = 3ones(dim),
+        p = [2.0i for i in 1:nout], alg, abstol, reltol
+    )
+    do_tests_mooncake(;
+        f, scalarize, lb = ones(dim), ub = 3ones(dim),
+        p = [2.0i for i in 1:nout], alg, abstol, reltol
+    )
 end
 
 #### in place IntegralCache, IntegralFunction Tests
 ### One Dimensional
 for (alg, req) in pairs(alg_req), (j, f) in enumerate(integrands),
-    (i, scalarize) in enumerate(scalarize_solution)
+        (i, scalarize) in enumerate(scalarize_solution)
     req.allows_iip || continue
     req.nout > 1 || continue
     req.min_dim <= 1 || continue
 
-    @info "One-dimensional, scalar, iip derivative test" alg=nameof(typeof(alg)) integrand=j scalarize=i
+    @info "One-dimensional, scalar, iip derivative test" alg = nameof(typeof(alg)) integrand = j scalarize = i
     fiip = IntegralFunction((y, x, p) -> f_helper!(f, y, x, p), zeros(1))
     do_tests(; f = fiip, scalarize, lb = 1.0, ub = 3.0, p = 2.0, alg, abstol, reltol)
     do_tests_mooncake(;
-        f = fiip, scalarize, lb = 1.0, ub = 3.0, p = 2.0, alg, abstol, reltol)
+        f = fiip, scalarize, lb = 1.0, ub = 3.0, p = 2.0, alg, abstol, reltol
+    )
 end
 
 ## One-dimensional nout
 for (alg, req) in pairs(alg_req), (j, f) in enumerate(integrands),
-    (i, scalarize) in enumerate(scalarize_solution), nout in 1:max_nout_test
+        (i, scalarize) in enumerate(scalarize_solution), nout in 1:max_nout_test
     req.allows_iip || continue
     req.nout > 1 || continue
     req.min_dim <= 1 || continue
 
-    @info "One-dimensional, multivariate, iip derivative test" alg=nameof(typeof(alg)) integrand=j scalarize=i nout
+    @info "One-dimensional, multivariate, iip derivative test" alg = nameof(typeof(alg)) integrand = j scalarize = i nout
     fiip = IntegralFunction((y, x, p) -> f_helper!(f, y, x, p), zeros(nout))
-    do_tests(; f = fiip, scalarize, lb = 1.0, ub = 3.0,
-        p = [2.0i for i in 1:nout], alg, abstol, reltol)
-    do_tests_mooncake(; f = fiip, scalarize, lb = 1.0, ub = 3.0,
-        p = [2.0i for i in 1:nout], alg, abstol, reltol)
+    do_tests(;
+        f = fiip, scalarize, lb = 1.0, ub = 3.0,
+        p = [2.0i for i in 1:nout], alg, abstol, reltol
+    )
+    do_tests_mooncake(;
+        f = fiip, scalarize, lb = 1.0, ub = 3.0,
+        p = [2.0i for i in 1:nout], alg, abstol, reltol
+    )
 end
 
 ### N-dimensional
 for (alg, req) in pairs(alg_req), (j, f) in enumerate(integrands),
-    (i, scalarize) in enumerate(scalarize_solution), dim in 1:max_dim_test
+        (i, scalarize) in enumerate(scalarize_solution), dim in 1:max_dim_test
     req.allows_iip || continue
     req.nout > 1 || continue
     req.min_dim <= dim <= req.max_dim || continue
 
-    @info "Multi-dimensional, scalar, iip derivative test" alg=nameof(typeof(alg)) integrand=j scalarize=i dim
+    @info "Multi-dimensional, scalar, iip derivative test" alg = nameof(typeof(alg)) integrand = j scalarize = i dim
     fiip = IntegralFunction((y, x, p) -> f_helper!(f, y, x, p), zeros(1))
     do_tests(;
-        f = fiip, scalarize, lb = ones(dim), ub = 3ones(dim), p = 2.0, alg, abstol, reltol)
+        f = fiip, scalarize, lb = ones(dim), ub = 3ones(dim), p = 2.0, alg, abstol, reltol
+    )
     do_tests_mooncake(;
-        f = fiip, scalarize, lb = ones(dim), ub = 3ones(dim), p = 2.0, alg, abstol, reltol)
+        f = fiip, scalarize, lb = ones(dim), ub = 3ones(dim), p = 2.0, alg, abstol, reltol
+    )
 end
 
 ### N-dimensional nout iip
 for (alg, req) in pairs(alg_req), (j, f) in enumerate(integrands),
-    (i, scalarize) in enumerate(scalarize_solution), dim in 1:max_dim_test,
-    nout in 1:max_nout_test
+        (i, scalarize) in enumerate(scalarize_solution), dim in 1:max_dim_test,
+        nout in 1:max_nout_test
     req.allows_iip || continue
     req.nout > 1 || continue
     req.min_dim <= dim <= req.max_dim || continue
 
-    @info "Multi-dimensional, multivariate, iip derivative test" alg=nameof(typeof(alg)) integrand=j scalarize=i dim nout
+    @info "Multi-dimensional, multivariate, iip derivative test" alg = nameof(typeof(alg)) integrand = j scalarize = i dim nout
     fiip = IntegralFunction((y, x, p) -> f_helper!(f, y, x, p), zeros(nout))
-    do_tests(; f = fiip, scalarize, lb = ones(dim), ub = 3ones(dim),
-        p = [2.0i for i in 1:nout], alg, abstol, reltol)
-    do_tests_mooncake(; f = fiip, scalarize, lb = ones(dim), ub = 3ones(dim),
-        p = [2.0i for i in 1:nout], alg, abstol, reltol)
+    do_tests(;
+        f = fiip, scalarize, lb = ones(dim), ub = 3ones(dim),
+        p = [2.0i for i in 1:nout], alg, abstol, reltol
+    )
+    do_tests_mooncake(;
+        f = fiip, scalarize, lb = ones(dim), ub = 3ones(dim),
+        p = [2.0i for i in 1:nout], alg, abstol, reltol
+    )
 end
 
 ### Batch, One Dimensional
 for (alg, req) in pairs(alg_req), (j, f) in enumerate(integrands),
-    (i, scalarize) in enumerate(scalarize_solution)
+        (i, scalarize) in enumerate(scalarize_solution)
     req.allows_batch || continue
     req.nout > 1 || continue
     req.min_dim <= 1 || continue
 
-    @info "Batched, one-dimensional, scalar, oop derivative test" alg=nameof(typeof(alg)) integrand=j scalarize=i
+    @info "Batched, one-dimensional, scalar, oop derivative test" alg = nameof(typeof(alg)) integrand = j scalarize = i
     bf = BatchIntegralFunction((x, p) -> batch_helper(f, x, p))
     do_tests(; f = bf, scalarize, lb = 1.0, ub = 3.0, p = 2.0, alg, abstol, reltol)
 end
 
 ## Batch, One-dimensional nout
 for (alg, req) in pairs(alg_req), (j, f) in enumerate(integrands),
-    (i, scalarize) in enumerate(scalarize_solution), nout in 1:max_nout_test
+        (i, scalarize) in enumerate(scalarize_solution), nout in 1:max_nout_test
     req.allows_batch || continue
     req.nout > 1 || continue
     req.min_dim <= 1 || continue
 
-    @info "Batched, one-dimensional, multivariate, oop derivative test" alg=nameof(typeof(alg)) integrand=j scalarize=i nout
+    @info "Batched, one-dimensional, multivariate, oop derivative test" alg = nameof(typeof(alg)) integrand = j scalarize = i nout
     bf = BatchIntegralFunction((x, p) -> batch_helper(f, x, p))
-    do_tests(; f = bf, scalarize, lb = 1.0, ub = 3.0,
-        p = [2.0i for i in 1:nout], alg, abstol, reltol)
+    do_tests(;
+        f = bf, scalarize, lb = 1.0, ub = 3.0,
+        p = [2.0i for i in 1:nout], alg, abstol, reltol
+    )
 end
 
 ### Batch, N-dimensional
 for (alg, req) in pairs(alg_req), (j, f) in enumerate(integrands),
-    (i, scalarize) in enumerate(scalarize_solution), dim in 1:max_dim_test
+        (i, scalarize) in enumerate(scalarize_solution), dim in 1:max_dim_test
     req.allows_batch || continue
     req.nout > 1 || continue
     req.min_dim <= dim <= req.max_dim || continue
 
-    @info "Batched, multi-dimensional, scalar, oop derivative test" alg=nameof(typeof(alg)) integrand=j scalarize=i dim
+    @info "Batched, multi-dimensional, scalar, oop derivative test" alg = nameof(typeof(alg)) integrand = j scalarize = i dim
     bf = BatchIntegralFunction((x, p) -> batch_helper(f, x, p))
     do_tests(;
-        f = bf, scalarize, lb = ones(dim), ub = 3ones(dim), p = 2.0, alg, abstol, reltol)
+        f = bf, scalarize, lb = ones(dim), ub = 3ones(dim), p = 2.0, alg, abstol, reltol
+    )
 end
 
 ### Batch, N-dimensional nout
 for (alg, req) in pairs(alg_req), (j, f) in enumerate(integrands),
-    (i, scalarize) in enumerate(scalarize_solution), dim in 1:max_dim_test,
-    nout in 1:max_nout_test
+        (i, scalarize) in enumerate(scalarize_solution), dim in 1:max_dim_test,
+        nout in 1:max_nout_test
     req.allows_batch || continue
     req.nout > 1 || continue
     req.min_dim <= dim <= req.max_dim || continue
 
-    @info "Batch, multi-dimensional, multivariate, oop derivative test" alg=nameof(typeof(alg)) integrand=j scalarize=i dim nout
+    @info "Batch, multi-dimensional, multivariate, oop derivative test" alg = nameof(typeof(alg)) integrand = j scalarize = i dim nout
     bf = BatchIntegralFunction((x, p) -> batch_helper(f, x, p))
-    do_tests(; f = bf, scalarize, lb = ones(dim), ub = 3ones(dim),
-        p = [2.0i for i in 1:nout], alg, abstol, reltol)
+    do_tests(;
+        f = bf, scalarize, lb = ones(dim), ub = 3ones(dim),
+        p = [2.0i for i in 1:nout], alg, abstol, reltol
+    )
 end
 
 ### Batch, one-dimensional
 for (alg, req) in pairs(alg_req), (j, f) in enumerate(integrands),
-    (i, scalarize) in enumerate(scalarize_solution)
+        (i, scalarize) in enumerate(scalarize_solution)
     req.allows_batch || continue
     req.allows_iip || continue
     req.nout > 1 || continue
     req.min_dim <= 1 || continue
 
-    @info "Batched, one-dimensional, scalar, iip derivative test" alg=nameof(typeof(alg)) integrand=j scalarize=i
+    @info "Batched, one-dimensional, scalar, iip derivative test" alg = nameof(typeof(alg)) integrand = j scalarize = i
     bfiip = BatchIntegralFunction((y, x, p) -> batch_helper!(f, y, x, p), zeros(0))
     do_tests(; f = bfiip, scalarize, lb = 1.0, ub = 3.0, p = 2.0, alg, abstol, reltol)
 end
 
 ## Batch, one-dimensional nout
 for (alg, req) in pairs(alg_req), (j, f) in enumerate(integrands),
-    (i, scalarize) in enumerate(scalarize_solution), nout in 1:max_nout_test
+        (i, scalarize) in enumerate(scalarize_solution), nout in 1:max_nout_test
     req.allows_batch || continue
     req.allows_iip || continue
     req.nout > 1 || continue
     req.min_dim <= 1 || continue
 
-    @info "Batched, one-dimensional, multivariate, iip derivative test" alg=nameof(typeof(alg)) integrand=j scalarize=i nout
+    @info "Batched, one-dimensional, multivariate, iip derivative test" alg = nameof(typeof(alg)) integrand = j scalarize = i nout
     bfiip = BatchIntegralFunction((y, x, p) -> batch_helper!(f, y, x, p), zeros(nout, 0))
-    do_tests(; f = bfiip, scalarize, lb = 1.0, ub = 3.0,
-        p = [2.0i for i in 1:nout], alg, abstol, reltol)
+    do_tests(;
+        f = bfiip, scalarize, lb = 1.0, ub = 3.0,
+        p = [2.0i for i in 1:nout], alg, abstol, reltol
+    )
 end
 
 ### Batch, N-dimensional
 for (alg, req) in pairs(alg_req), (j, f) in enumerate(integrands),
-    (i, scalarize) in enumerate(scalarize_solution), dim in 1:max_dim_test
+        (i, scalarize) in enumerate(scalarize_solution), dim in 1:max_dim_test
     req.allows_batch || continue
     req.allows_iip || continue
     req.nout > 1 || continue
     req.min_dim <= dim <= req.max_dim || continue
 
-    @info "Batched, multi-dimensional, scalar, iip derivative test" alg=nameof(typeof(alg)) integrand=j scalarize=i dim
+    @info "Batched, multi-dimensional, scalar, iip derivative test" alg = nameof(typeof(alg)) integrand = j scalarize = i dim
     bfiip = BatchIntegralFunction((y, x, p) -> batch_helper!(f, y, x, p), zeros(0))
-    do_tests(; f = bfiip, scalarize, lb = ones(dim),
-        ub = 3ones(dim), p = 2.0, alg, abstol, reltol)
+    do_tests(;
+        f = bfiip, scalarize, lb = ones(dim),
+        ub = 3ones(dim), p = 2.0, alg, abstol, reltol
+    )
 end
 
 ### Batch, N-dimensional nout iip
 for (alg, req) in pairs(alg_req), (j, f) in enumerate(integrands),
-    (i, scalarize) in enumerate(scalarize_solution), dim in 1:max_dim_test,
-    nout in 1:max_nout_test
+        (i, scalarize) in enumerate(scalarize_solution), dim in 1:max_dim_test,
+        nout in 1:max_nout_test
     req.allows_batch || continue
     req.allows_iip || continue
     req.nout > 1 || continue
     req.min_dim <= dim <= req.max_dim || continue
 
-    @info "Batched, multi-dimensional, multivariate, iip derivative test" alg=nameof(typeof(alg)) integrand=j scalarize=i dim nout
+    @info "Batched, multi-dimensional, multivariate, iip derivative test" alg = nameof(typeof(alg)) integrand = j scalarize = i dim nout
     bfiip = BatchIntegralFunction((y, x, p) -> batch_helper!(f, y, x, p), zeros(nout, 0))
-    do_tests(; f = bfiip, scalarize, lb = ones(dim), ub = 3ones(dim),
-        p = [2.0i for i in 1:nout], alg, abstol, reltol)
+    do_tests(;
+        f = bfiip, scalarize, lb = ones(dim), ub = 3ones(dim),
+        p = [2.0i for i in 1:nout], alg, abstol, reltol
+    )
 end
 
 @testset "ChangeOfVariables rrules" begin
@@ -426,14 +479,16 @@ end
     talg = Integrals.ChangeOfVariables(alg) do f, domain
         if f isa IntegralFunction{false}
             IntegralFunction((x, p) -> f((x - 1.3) / 2.7, p) / 2.7),
-            map(x -> 1.3 + 2.7x, domain)
+                map(x -> 1.3 + 2.7x, domain)
         else
             error("not implemented")
         end
     end
 
-    testf = (f, lb, ub, p, alg,
-        sensealg) -> begin
+    testf = (
+        f, lb, ub, p, alg,
+        sensealg,
+    ) -> begin
         prob = IntegralProblem(f, (lb, ub), p)
         solve(prob, alg; abstol, reltol, sensealg = sensealg).u
     end
@@ -443,9 +498,11 @@ end
     @testset "Sensitivity using Zygote" begin
         sensealg = Integrals.ReCallVJP(Integrals.ZygoteVJP())
         sol = Zygote.withgradient(
-            (args...) -> testf(_testf, args...), lb, ub, p, alg, sensealg)
+            (args...) -> testf(_testf, args...), lb, ub, p, alg, sensealg
+        )
         tsol = Zygote.withgradient(
-            (args...) -> testf(_testf, args...), lb, ub, p, talg, sensealg)
+            (args...) -> testf(_testf, args...), lb, ub, p, talg, sensealg
+        )
         @test sol.val ≈ tsol.val
         # Fundamental theorem of Calculus part 1
         @test sol.grad[1] ≈ tsol.grad[1] ≈ -_testf(lb, p)
@@ -459,12 +516,15 @@ end
         # anonymous function for cache creation and gradient evaluation call must be the same.
         func = (args...) -> testf(_testf, args...)
         cache = Mooncake.prepare_gradient_cache(func, lb, ub, p, alg, sensealg)
-        sol = Mooncake.value_and_gradient!!(cache, func,
-            lb, ub, p, alg, sensealg)
+        sol = Mooncake.value_and_gradient!!(
+            cache, func,
+            lb, ub, p, alg, sensealg
+        )
 
         cache = Mooncake.prepare_gradient_cache(func, lb, ub, p, talg, sensealg)
         tsol = Mooncake.value_and_gradient!!(
-            cache, func, lb, ub, p, talg, sensealg)
+            cache, func, lb, ub, p, talg, sensealg
+        )
 
         @test sol[1] ≈ tsol[1]
         # Fundamental theorem of Calculus part 1
@@ -507,5 +567,5 @@ end
 
     # Compare with ForwardDiff for correctness
     grad_fd = ForwardDiff.gradient(loss_explicit_p, ps)
-    @test grad_explicit ≈ grad_fd rtol = 1e-5
+    @test grad_explicit ≈ grad_fd rtol = 1.0e-5
 end

--- a/test/explicit_imports_tests.jl
+++ b/test/explicit_imports_tests.jl
@@ -7,5 +7,5 @@ using LinearAlgebra: norm
     @test check_no_implicit_imports(Integrals) === nothing
     # Note: norm is used in default parameters in included files (algorithms.jl)
     # which ExplicitImports may not detect properly, so we ignore it
-    @test check_no_stale_explicit_imports(Integrals; ignore=(:norm,)) === nothing
+    @test check_no_stale_explicit_imports(Integrals; ignore = (:norm,)) === nothing
 end

--- a/test/inf_integral_tests.jl
+++ b/test/inf_integral_tests.jl
@@ -1,20 +1,29 @@
 using Integrals, Distributions, Test, Cubature, FastGaussQuadrature, StaticArrays
 
 reltol = 0.0
-abstol = 1e-3
+abstol = 1.0e-3
 
 # not all quadratures are compatible with infinities if they evaluate the endpoints
 alg_req = Dict(
-    QuadratureRule(gausslegendre,
-        n = 50) => (
+    QuadratureRule(
+        gausslegendre,
+        n = 50
+    ) => (
         nout = Inf, min_dim = 1, max_dim = 1, allows_batch = false,
-        allows_iip = false, allows_inf = true),
-    QuadGKJL() => (nout = Inf, allows_batch = true, min_dim = 1, max_dim = 1,
-        allows_iip = true, allows_inf = true),
-    HCubatureJL() => (nout = Inf, allows_batch = false, min_dim = 1,
-        max_dim = Inf, allows_iip = true, allows_inf = true),
-    CubatureJLh() => (nout = Inf, allows_batch = true, min_dim = 1,
-        max_dim = Inf, allows_iip = true, allows_inf = true)
+        allows_iip = false, allows_inf = true,
+    ),
+    QuadGKJL() => (
+        nout = Inf, allows_batch = true, min_dim = 1, max_dim = 1,
+        allows_iip = true, allows_inf = true,
+    ),
+    HCubatureJL() => (
+        nout = Inf, allows_batch = false, min_dim = 1,
+        max_dim = Inf, allows_iip = true, allows_inf = true,
+    ),
+    CubatureJLh() => (
+        nout = Inf, allows_batch = true, min_dim = 1,
+        max_dim = Inf, allows_iip = true, allows_inf = true,
+    )
 )
 # GaussLegendre(n=50) => (nout = Inf, min_dim = 1, max_dim = 1, allows_batch = false,
 #     allows_iip = false, allows_inf=true),
@@ -31,106 +40,126 @@ alg_req = Dict(
 # CubaCuhre() => (nout = Inf, allows_batch = true, min_dim = 2, max_dim = Inf,
 #     allows_iip = true),
 problems = (
-    (; # 1. multi-variate infinite limits: Gaussian
-        f = (x, p) -> pdf(MvNormal([0.00, 0.00], [0.4 0.0; 0.00 0.4]), x),
+    (;
+        # 1. multi-variate infinite limits: Gaussian
+        f = (x, p) -> pdf(MvNormal([0.0, 0.0], [0.4 0.0; 0.0 0.4]), x),
         domain = (@SVector[-Inf, -Inf], @SVector[Inf, Inf]),
-        solution = 1.00
+        solution = 1.0
     ),
-    (; # 2. multi-variate flipped infinite limits: Gaussian
-        f = (x, p) -> pdf(MvNormal([0.00, 0.00], [0.4 0.0; 0.00 0.4]), x),
+    (;
+        # 2. multi-variate flipped infinite limits: Gaussian
+        f = (x, p) -> pdf(MvNormal([0.0, 0.0], [0.4 0.0; 0.0 0.4]), x),
         domain = (@SVector[Inf, Inf], @SVector[-Inf, -Inf]),
-        solution = 1.00
+        solution = 1.0
     ),
-    (; # 3. multi-variate mixed infinite/semi-infinite upper limit: Gaussian
-        f = (x, p) -> pdf(MvNormal([0.00, 0.00], [0.4 0.0; 0.00 0.4]), x),
+    (;
+        # 3. multi-variate mixed infinite/semi-infinite upper limit: Gaussian
+        f = (x, p) -> pdf(MvNormal([0.0, 0.0], [0.4 0.0; 0.0 0.4]), x),
         domain = (@SVector[-Inf, 0], @SVector[Inf, Inf]),
         solution = 0.5
     ),
-    (; # 4. multi-variate mixed infinite/semi-infinite lower limit: Gaussian
-        f = (x, p) -> pdf(MvNormal([0.00, 0.00], [0.4 0.0; 0.00 0.4]), x),
+    (;
+        # 4. multi-variate mixed infinite/semi-infinite lower limit: Gaussian
+        f = (x, p) -> pdf(MvNormal([0.0, 0.0], [0.4 0.0; 0.0 0.4]), x),
         domain = (@SVector[-Inf, -Inf], @SVector[Inf, 0]),
         solution = 0.5
     ),
-    (; # 5. multi-variate mixed infinite/finite: Gaussian * quadratic
-        f = (x, p) -> pdf(Normal(0.00, 1.00), x[1]) * x[2]^2,
+    (;
+        # 5. multi-variate mixed infinite/finite: Gaussian * quadratic
+        f = (x, p) -> pdf(Normal(0.0, 1.0), x[1]) * x[2]^2,
         domain = (@SVector[-Inf, 1], @SVector[Inf, 4]),
         solution = 21.0
     ),
-    (; # 6. multi-variate mixed semi-infinite lower limit/finite: Gaussian * quadratic
-        f = (x, p) -> pdf(Normal(0.00, 1.00), x[1]) * x[2]^2,
-        domain = (@SVector[0.00, 1], @SVector[Inf, 4]),
+    (;
+        # 6. multi-variate mixed semi-infinite lower limit/finite: Gaussian * quadratic
+        f = (x, p) -> pdf(Normal(0.0, 1.0), x[1]) * x[2]^2,
+        domain = (@SVector[0.0, 1], @SVector[Inf, 4]),
         solution = 10.5
     ),
-    (; # 7. multi-variate mixed semi-infinite upper limit/finite: Gaussian * quadratic
-        f = (x, p) -> pdf(Normal(0.00, 1.00), x[1]) * x[2]^2,
-        domain = (@SVector[-Inf, 1], @SVector[0.00, 4]),
+    (;
+        # 7. multi-variate mixed semi-infinite upper limit/finite: Gaussian * quadratic
+        f = (x, p) -> pdf(Normal(0.0, 1.0), x[1]) * x[2]^2,
+        domain = (@SVector[-Inf, 1], @SVector[0.0, 4]),
         solution = 10.5
     ),
-    (; # 8. single-variable infinite limit: Gaussian
-        f = (x, p) -> pdf(Normal(0.00, 1.00), x),
+    (;
+        # 8. single-variable infinite limit: Gaussian
+        f = (x, p) -> pdf(Normal(0.0, 1.0), x),
         domain = (-Inf, Inf),
-        solution = 1.0
+        solution = 1.0,
     ),
-    (; # 9. single-variable flipped infinite limit: Gaussian
-        f = (x, p) -> pdf(Normal(0.00, 1.00), x),
+    (;
+        # 9. single-variable flipped infinite limit: Gaussian
+        f = (x, p) -> pdf(Normal(0.0, 1.0), x),
         domain = (Inf, -Inf),
-        solution = -1.0
+        solution = -1.0,
     ),
-    (; # 10. single-variable semi-infinite upper limit: Gaussian
-        f = (x, p) -> pdf(Normal(0.00, 1.00), x),
-        domain = (0.00, Inf),
-        solution = 0.5
+    (;
+        # 10. single-variable semi-infinite upper limit: Gaussian
+        f = (x, p) -> pdf(Normal(0.0, 1.0), x),
+        domain = (0.0, Inf),
+        solution = 0.5,
     ),
-    (; # 11. single-variable flipped, semi-infinite upper limit: Gaussian
-        f = (x, p) -> pdf(Normal(0.00, 1.00), x),
-        domain = (0.00, -Inf),
-        solution = -0.5
+    (;
+        # 11. single-variable flipped, semi-infinite upper limit: Gaussian
+        f = (x, p) -> pdf(Normal(0.0, 1.0), x),
+        domain = (0.0, -Inf),
+        solution = -0.5,
     ),
-    (; # 12. single-variable semi-infinite lower limit: Gaussian
-        f = (x, p) -> pdf(Normal(0.00, 1.00), x),
-        domain = (-Inf, 0.00),
-        solution = 0.5
+    (;
+        # 12. single-variable semi-infinite lower limit: Gaussian
+        f = (x, p) -> pdf(Normal(0.0, 1.0), x),
+        domain = (-Inf, 0.0),
+        solution = 0.5,
     ),
-    (; # 13. single-variable flipped, semi-infinite lower limit: Gaussian
-        f = (x, p) -> pdf(Normal(0.00, 1.00), x),
-        domain = (Inf, 0.00),
-        solution = -0.5
+    (;
+        # 13. single-variable flipped, semi-infinite lower limit: Gaussian
+        f = (x, p) -> pdf(Normal(0.0, 1.0), x),
+        domain = (Inf, 0.0),
+        solution = -0.5,
     ),
-    (; # 14. single-variable infinite limit: Lorentzian
+    (;
+        # 14. single-variable infinite limit: Lorentzian
         f = (x, p) -> 1 / (x^2 + 1),
         domain = (-Inf, Inf),
-        solution = pi / 1
+        solution = pi / 1,
     ),
-    (; # 15. single-variable shifted, semi-infinite lower limit: Lorentzian
+    (;
+        # 15. single-variable shifted, semi-infinite lower limit: Lorentzian
         f = (x, p) -> 1 / ((x - 2)^2 + 1),
         domain = (-Inf, 2),
-        solution = pi / 2
+        solution = pi / 2,
     ),
-    (; # 16. single-variable shifted, semi-infinite upper limit: Lorentzian
+    (;
+        # 16. single-variable shifted, semi-infinite upper limit: Lorentzian
         f = (x, p) -> 1 / ((x - 2)^2 + 1),
         domain = (2, Inf),
-        solution = pi / 2
+        solution = pi / 2,
     ),
-    (; # 17. single-variable flipped, shifted, semi-infinite lower limit: Lorentzian
+    (;
+        # 17. single-variable flipped, shifted, semi-infinite lower limit: Lorentzian
         f = (x, p) -> 1 / ((x - 2)^2 + 1),
         domain = (Inf, 2),
-        solution = -pi / 2
+        solution = -pi / 2,
     ),
-    (; # 18. single-variable flipped, shifted, semi-infinite upper limit: Lorentzian
+    (;
+        # 18. single-variable flipped, shifted, semi-infinite upper limit: Lorentzian
         f = (x, p) -> 1 / ((x - 2)^2 + 1),
         domain = (2, -Inf),
-        solution = -pi / 2
+        solution = -pi / 2,
     ),
-    (; # 19. single-variable finite limits: quadratic
+    (;
+        # 19. single-variable finite limits: quadratic
         f = (x, p) -> x^2,
         domain = (1, 4),
-        solution = 21
+        solution = 21,
     ),
-    (; # 20. single-variable flipped, finite limits: quadratic
+    (;
+        # 20. single-variable flipped, finite limits: quadratic
         f = (x, p) -> x^2,
         domain = (4, 1),
-        solution = -21
-    )
+        solution = -21,
+    ),
 )
 
 function f_helper!(f, y, x, p)
@@ -139,7 +168,7 @@ function f_helper!(f, y, x, p)
 end
 
 function batch_helper(f, x, p)
-    map(i -> f(x[axes(x)[begin:(end - 1)]..., i], p), axes(x)[end])
+    return map(i -> f(x[axes(x)[begin:(end - 1)]..., i], p), axes(x)[end])
 end
 
 function batch_helper!(f, y, x, p)
@@ -153,7 +182,7 @@ do_tests = function (; f, domain, alg, abstol, reltol, solution)
     @test abs(only(sol) - solution) < max(abstol, reltol * abs(solution))
     cache = @test_nowarn @inferred init(prob, alg)
     @test_nowarn @inferred solve!(cache)
-    @test_nowarn @inferred solve(prob, alg)
+    return @test_nowarn @inferred solve(prob, alg)
 end
 
 # IntegralFunction{false}
@@ -163,7 +192,7 @@ for (alg, req) in pairs(alg_req), (j, (; f, domain, solution)) in enumerate(prob
     req.nout >= length(solution) || continue
     req.min_dim <= length(first(domain)) <= req.max_dim || continue
 
-    @info "oop infinity test" alg=nameof(typeof(alg)) problem=j
+    @info "oop infinity test" alg = nameof(typeof(alg)) problem = j
     do_tests(; f, domain, solution, alg, abstol, reltol)
 end
 
@@ -175,7 +204,7 @@ for (alg, req) in pairs(alg_req), (j, (; f, domain, solution)) in enumerate(prob
     req.allows_iip || continue
     req.min_dim <= length(first(domain)) <= req.max_dim || continue
 
-    @info "iip infinity test" alg=nameof(typeof(alg)) problem=j
+    @info "iip infinity test" alg = nameof(typeof(alg)) problem = j
     fiip = IntegralFunction((y, x, p) -> f_helper!(f, y, x, p), zeros(size(solution)))
     do_tests(; f = fiip, domain, solution, alg, abstol, reltol)
 end
@@ -188,7 +217,7 @@ for (alg, req) in pairs(alg_req), (j, (; f, domain, solution)) in enumerate(prob
     req.allows_batch || continue
     req.min_dim <= length(first(domain)) <= req.max_dim || continue
 
-    @info "Batched, oop infinity test" alg=nameof(typeof(alg)) problem=j
+    @info "Batched, oop infinity test" alg = nameof(typeof(alg)) problem = j
     bf = BatchIntegralFunction((x, p) -> batch_helper(f, x, p))
     do_tests(; f = bf, domain, solution, alg, abstol, reltol)
 end
@@ -202,14 +231,14 @@ for (alg, req) in pairs(alg_req), (j, (; f, domain, solution)) in enumerate(prob
     req.allows_iip || continue
     req.min_dim <= length(first(domain)) <= req.max_dim || continue
 
-    @info "Batched, iip infinity test" alg=nameof(typeof(alg)) problem=j
+    @info "Batched, iip infinity test" alg = nameof(typeof(alg)) problem = j
     bfiip = BatchIntegralFunction((y, x, p) -> batch_helper!(f, y, x, p), zeros(0))
     do_tests(; f = bfiip, domain, solution, alg, abstol, reltol)
 end
 
 @testset "Caching interface" begin
     # two distinct semi-infinite transformations should still work as expected
-    f = (x, p) -> pdf(Normal(0.00, 1.00), x)
+    f = (x, p) -> pdf(Normal(0.0, 1.0), x)
     domain = (0.0, -Inf)
     solution = -0.5
     prob = IntegralProblem(f, domain)

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -4,60 +4,88 @@ using Test
 
 max_dim_test = 2
 max_nout_test = 2
-reltol = 1e-5
-abstol = 1e-5
+reltol = 1.0e-5
+abstol = 1.0e-5
 
 alg_req = Dict(
-    QuadGKJL() => (nout = Inf, allows_batch = true, min_dim = 1, max_dim = 1,
-        allows_iip = true),
-    QuadratureRule(gausslegendre,
-        n = 50) => (
+    QuadGKJL() => (
+        nout = Inf, allows_batch = true, min_dim = 1, max_dim = 1,
+        allows_iip = true,
+    ),
+    QuadratureRule(
+        gausslegendre,
+        n = 50
+    ) => (
         nout = Inf, min_dim = 1, max_dim = 1, allows_batch = false,
-        allows_iip = false),
-    GaussLegendre() => (nout = Inf, min_dim = 1, max_dim = 1, allows_batch = false,
-        allows_iip = false),
-    HCubatureJL() => (nout = Inf, allows_batch = false, min_dim = 1,
-        max_dim = Inf, allows_iip = true),
-    VEGAS(seed = 109) => (nout = 1, allows_batch = true, min_dim = 2, max_dim = Inf,
-        allows_iip = true),
-    VEGASMC(seed = 42) => (nout = Inf, allows_batch = false, min_dim = 1, max_dim = Inf,
-        allows_iip = true),
-    CubatureJLh() => (nout = Inf, allows_batch = true, min_dim = 1,
-        max_dim = Inf, allows_iip = true),
-    CubatureJLp() => (nout = Inf, allows_batch = true, min_dim = 1,
-        max_dim = Inf, allows_iip = true),
-    CubaVegas() => (nout = Inf, allows_batch = true, min_dim = 1, max_dim = Inf,
-        allows_iip = true),
-    CubaSUAVE() => (nout = Inf, allows_batch = true, min_dim = 1, max_dim = Inf,
-        allows_iip = true),
-    CubaDivonne() => (nout = Inf, allows_batch = true, min_dim = 2,
-        max_dim = Inf, allows_iip = true),
-    CubaCuhre() => (nout = Inf, allows_batch = true, min_dim = 2, max_dim = Inf,
-        allows_iip = true),
+        allows_iip = false,
+    ),
+    GaussLegendre() => (
+        nout = Inf, min_dim = 1, max_dim = 1, allows_batch = false,
+        allows_iip = false,
+    ),
+    HCubatureJL() => (
+        nout = Inf, allows_batch = false, min_dim = 1,
+        max_dim = Inf, allows_iip = true,
+    ),
+    VEGAS(seed = 109) => (
+        nout = 1, allows_batch = true, min_dim = 2, max_dim = Inf,
+        allows_iip = true,
+    ),
+    VEGASMC(seed = 42) => (
+        nout = Inf, allows_batch = false, min_dim = 1, max_dim = Inf,
+        allows_iip = true,
+    ),
+    CubatureJLh() => (
+        nout = Inf, allows_batch = true, min_dim = 1,
+        max_dim = Inf, allows_iip = true,
+    ),
+    CubatureJLp() => (
+        nout = Inf, allows_batch = true, min_dim = 1,
+        max_dim = Inf, allows_iip = true,
+    ),
+    CubaVegas() => (
+        nout = Inf, allows_batch = true, min_dim = 1, max_dim = Inf,
+        allows_iip = true,
+    ),
+    CubaSUAVE() => (
+        nout = Inf, allows_batch = true, min_dim = 1, max_dim = Inf,
+        allows_iip = true,
+    ),
+    CubaDivonne() => (
+        nout = Inf, allows_batch = true, min_dim = 2,
+        max_dim = Inf, allows_iip = true,
+    ),
+    CubaCuhre() => (
+        nout = Inf, allows_batch = true, min_dim = 2, max_dim = Inf,
+        allows_iip = true,
+    ),
     ArblibJL() => (
-        nout = 1, allows_batch = false, min_dim = 1, max_dim = 1, allows_iip = false)
+        nout = 1, allows_batch = false, min_dim = 1, max_dim = 1, allows_iip = false,
+    )
 )
 
 integrands = [
     (x, p) -> 1.0,
-    (x, p) -> x isa Number ? cos(x) : prod(cos.(x))
+    (x, p) -> x isa Number ? cos(x) : prod(cos.(x)),
 ]
 iip_integrands = [(dx, x, p) -> (dx .= f(x, p)) for f in integrands]
 
-integrands_v = [(x, p, nout) -> collect(1.0:nout)
-                let f = integrands[2]
-                    (x, p, nout) -> f(x, p) * collect(1.0:nout)
-                end]
+integrands_v = [
+    (x, p, nout) -> collect(1.0:nout)
+    let f = integrands[2]
+        (x, p, nout) -> f(x, p) * collect(1.0:nout)
+    end
+]
 iip_integrands_v = [(dx, x, p, nout) -> (dx .= f(x, p, nout)) for f in integrands_v]
 
 exact_sol = [
     (ndim, nout, lb, ub) -> prod(ub - lb),
-    (ndim, nout, lb, ub) -> prod(sin.(ub) - sin.(lb))
+    (ndim, nout, lb, ub) -> prod(sin.(ub) - sin.(lb)),
 ]
 
 exact_sol_v = [
     (ndim, nout, lb, ub) -> prod(ub - lb) * collect(1.0:nout),
-    (ndim, nout, lb, ub) -> exact_sol[2](ndim, nout, lb, ub) * collect(1:nout)
+    (ndim, nout, lb, ub) -> exact_sol[2](ndim, nout, lb, ub) * collect(1:nout),
 ]
 
 batch_f(f) = (pts, p) -> begin
@@ -108,7 +136,7 @@ end
             @info "Alg = $(nameof(typeof(alg))), Integrand = $i, Dimension = $dim, Output Dimension = $nout"
             sol = @inferred solve(prob, alg, reltol = reltol, abstol = abstol)
             @test sol.alg == alg
-            @test sol.u≈exact_sol[i](dim, nout, lb, ub) rtol=1e-2
+            @test sol.u ≈ exact_sol[i](dim, nout, lb, ub) rtol = 1.0e-2
         end
     end
 end
@@ -126,7 +154,7 @@ end
                 @info "Alg = $(nameof(typeof(alg))), Integrand = $i, Dimension = $dim, Output Dimension = $nout"
                 sol = @inferred solve(prob, alg, reltol = reltol, abstol = abstol)
                 @test sol.alg == alg
-                @test sol.u≈exact_sol[i](dim, nout, lb, ub) rtol=1e-2
+                @test sol.u ≈ exact_sol[i](dim, nout, lb, ub) rtol = 1.0e-2
             end
         end
     end
@@ -146,9 +174,9 @@ end
                 sol = @inferred solve(prob, alg, reltol = reltol, abstol = abstol)
                 @test sol.alg == alg
                 if sol.u isa Number
-                    @test sol.u≈exact_sol[i](dim, nout, lb, ub) rtol=1e-2
+                    @test sol.u ≈ exact_sol[i](dim, nout, lb, ub) rtol = 1.0e-2
                 else
-                    @test sol.u≈[exact_sol[i](dim, nout, lb, ub)] rtol=1e-2
+                    @test sol.u ≈ [exact_sol[i](dim, nout, lb, ub)] rtol = 1.0e-2
                 end
             end
         end
@@ -167,7 +195,7 @@ end
             @info "Alg = $(nameof(typeof(alg))), Integrand = $i, Dimension = $dim, Output Dimension = $nout"
             sol = @inferred solve(prob, alg, reltol = reltol, abstol = abstol)
             @test sol.alg == alg
-            @test sol.u[1]≈exact_sol[i](dim, nout, lb, ub) rtol=1e-2
+            @test sol.u[1] ≈ exact_sol[i](dim, nout, lb, ub) rtol = 1.0e-2
         end
     end
 end
@@ -178,8 +206,11 @@ end
         for i in 1:length(integrands)
             for dim in 1:max_dim_test
                 (lb, ub) = (ones(dim), 3ones(dim))
-                prob = IntegralProblem(BatchIntegralFunction(batch_f(integrands[i])), (
-                    lb, ub))
+                prob = IntegralProblem(
+                    BatchIntegralFunction(batch_f(integrands[i])), (
+                        lb, ub,
+                    )
+                )
                 if dim > req.max_dim || dim < req.min_dim || !req.allows_batch
                     continue
                 end
@@ -187,9 +218,9 @@ end
                 sol = @inferred solve(prob, alg, reltol = reltol, abstol = abstol)
                 @test sol.alg == alg
                 if sol.u isa Number
-                    @test sol.u≈exact_sol[i](dim, nout, lb, ub) rtol=1e-2
+                    @test sol.u ≈ exact_sol[i](dim, nout, lb, ub) rtol = 1.0e-2
                 else
-                    @test sol.u≈[exact_sol[i](dim, nout, lb, ub)] rtol=1e-2
+                    @test sol.u ≈ [exact_sol[i](dim, nout, lb, ub)] rtol = 1.0e-2
                 end
             end
         end
@@ -204,18 +235,19 @@ end
                 (lb, ub) = (ones(dim), 3ones(dim))
                 prob = IntegralProblem(
                     BatchIntegralFunction(batch_iip_f(integrands[i]), zeros(0), max_batch = 1000),
-                    (lb, ub))
+                    (lb, ub)
+                )
                 if dim > req.max_dim || dim < req.min_dim || !req.allows_batch ||
-                   !req.allows_iip
+                        !req.allows_iip
                     continue
                 end
                 @info "Alg = $(nameof(typeof(alg))), Integrand = $i, Dimension = $dim, Output Dimension = $nout"
                 sol = @inferred solve(prob, alg, reltol = reltol, abstol = abstol)
                 @test sol.alg == alg
                 if sol.u isa Number
-                    @test sol.u≈exact_sol[i](dim, nout, lb, ub) rtol=1e-2
+                    @test sol.u ≈ exact_sol[i](dim, nout, lb, ub) rtol = 1.0e-2
                 else
-                    @test sol.u≈[exact_sol[i](dim, nout, lb, ub)] rtol=1e-2
+                    @test sol.u ≈ [exact_sol[i](dim, nout, lb, ub)] rtol = 1.0e-2
                 end
             end
         end
@@ -240,9 +272,9 @@ end
                 sol = @inferred solve(prob, alg, reltol = reltol, abstol = abstol)
                 @test sol.alg == alg
                 if nout == 1
-                    @test sol.u[1]≈exact_sol_v[i](dim, nout, lb, ub)[1] rtol=1e-2
+                    @test sol.u[1] ≈ exact_sol_v[i](dim, nout, lb, ub)[1] rtol = 1.0e-2
                 else
-                    @test sol.u≈exact_sol_v[i](dim, nout, lb, ub) rtol=1e-2
+                    @test sol.u ≈ exact_sol_v[i](dim, nout, lb, ub) rtol = 1.0e-2
                 end
             end
         end
@@ -266,9 +298,9 @@ end
                     sol = @inferred solve(prob, alg, reltol = reltol, abstol = abstol)
                     @test sol.alg == alg
                     if nout == 1
-                        @test sol.u[1]≈exact_sol_v[i](dim, nout, lb, ub)[1] rtol=1e-2
+                        @test sol.u[1] ≈ exact_sol_v[i](dim, nout, lb, ub)[1] rtol = 1.0e-2
                     else
-                        @test sol.u≈exact_sol_v[i](dim, nout, lb, ub) rtol=1e-2
+                        @test sol.u ≈ exact_sol_v[i](dim, nout, lb, ub) rtol = 1.0e-2
                     end
                 end
             end
@@ -287,16 +319,16 @@ end
                     end
                     prob = IntegralProblem(integrand_f, (lb, ub))
                     if dim > req.max_dim || dim < req.min_dim || req.nout < nout ||
-                       !req.allows_iip
+                            !req.allows_iip
                         continue
                     end
                     @info "Alg = $(nameof(typeof(alg))), Integrand = $i, Dimension = $dim, Output Dimension = $nout"
                     sol = @inferred solve(prob, alg, reltol = reltol, abstol = abstol)
                     @test sol.alg == alg
                     if nout == 1
-                        @test sol.u[1]≈exact_sol_v[i](dim, nout, lb, ub)[1] rtol=1e-2
+                        @test sol.u[1] ≈ exact_sol_v[i](dim, nout, lb, ub)[1] rtol = 1.0e-2
                     else
-                        @test sol.u≈exact_sol_v[i](dim, nout, lb, ub) rtol=1e-2
+                        @test sol.u ≈ exact_sol_v[i](dim, nout, lb, ub) rtol = 1.0e-2
                     end
                 end
             end
@@ -309,15 +341,18 @@ end
     (dim, nout) = (1, 2)
     for (alg, req) in pairs(alg_req)
         for i in 1:length(integrands_v)
-            prob = IntegralProblem(BatchIntegralFunction(batch_f_v(integrands_v[i], nout)), (
-                lb, ub))
+            prob = IntegralProblem(
+                BatchIntegralFunction(batch_f_v(integrands_v[i], nout)), (
+                    lb, ub,
+                )
+            )
             if req.min_dim > 1 || !req.allows_batch || req.nout < nout
                 continue
             end
             @info "Alg = $(nameof(typeof(alg))), Integrand = $i, Dimension = $dim, Output Dimension = $nout"
             sol = @inferred solve(prob, alg, reltol = reltol, abstol = abstol)
             @test sol.alg == alg
-            @test sol.u≈exact_sol_v[i](dim, nout, lb, ub) rtol=1e-2
+            @test sol.u ≈ exact_sol_v[i](dim, nout, lb, ub) rtol = 1.0e-2
         end
     end
 end
@@ -328,16 +363,19 @@ end
         for i in 1:length(integrands_v)
             for dim in 1:max_dim_test
                 (lb, ub) = (ones(dim), 3ones(dim))
-                prob = IntegralProblem(BatchIntegralFunction(batch_f_v(integrands_v[i], nout)), (
-                    lb, ub))
+                prob = IntegralProblem(
+                    BatchIntegralFunction(batch_f_v(integrands_v[i], nout)), (
+                        lb, ub,
+                    )
+                )
                 if dim > req.max_dim || dim < req.min_dim || !req.allows_batch ||
-                   req.nout < nout
+                        req.nout < nout
                     continue
                 end
                 @info "Alg = $(nameof(typeof(alg))), Integrand = $i, Dimension = $dim, Output Dimension = $nout"
                 sol = @inferred solve(prob, alg, reltol = reltol, abstol = abstol)
                 @test sol.alg == alg
-                @test sol.u≈exact_sol_v[i](dim, nout, lb, ub) rtol=1e-2
+                @test sol.u ≈ exact_sol_v[i](dim, nout, lb, ub) rtol = 1.0e-2
             end
         end
     end
@@ -351,15 +389,16 @@ end
                 (lb, ub) = (ones(dim), 3ones(dim))
                 prob = IntegralProblem(
                     BatchIntegralFunction(batch_iip_f_v(integrands_v[i], nout), zeros(nout, 0)),
-                    (lb, ub))
+                    (lb, ub)
+                )
                 if dim > req.max_dim || dim < req.min_dim || !req.allows_batch ||
-                   !req.allows_iip || req.nout < nout
+                        !req.allows_iip || req.nout < nout
                     continue
                 end
                 @info "Alg = $(nameof(typeof(alg))), Integrand = $i, Dimension = $dim, Output Dimension = $nout"
                 sol = @inferred solve(prob, alg, reltol = reltol, abstol = abstol)
                 @test sol.alg == alg
-                @test sol.u≈exact_sol_v[i](dim, nout, lb, ub) rtol=1e-2
+                @test sol.u ≈ exact_sol_v[i](dim, nout, lb, ub) rtol = 1.0e-2
             end
         end
     end
@@ -368,11 +407,12 @@ end
 @testset "Allowed keyword test" begin
     f(u, p) = sum(sin.(u))
     prob = IntegralProblem(f, ones(3), 3ones(3))
-    @test_throws Integrals.CommonKwargError((:relztol => 1e-3, :abstol => 1e-3)) solve(
+    @test_throws Integrals.CommonKwargError((:relztol => 1.0e-3, :abstol => 1.0e-3)) solve(
         prob,
         HCubatureJL();
-        relztol = 1e-3,
-        abstol = 1e-3)
+        relztol = 1.0e-3,
+        abstol = 1.0e-3
+    )
 end
 
 @testset "Caching interface" begin
@@ -387,13 +427,13 @@ end
         for i in 1:length(integrands)
             prob = IntegralProblem(integrands[i], (lb, ub), p)
             cache = init(prob, alg, reltol = reltol, abstol = abstol)
-            @test solve!(cache).u≈exact_sol[i](dim, nout, lb, ub) rtol=1e-2
+            @test solve!(cache).u ≈ exact_sol[i](dim, nout, lb, ub) rtol = 1.0e-2
             cache.lb = lb = 0.5
-            @test solve!(cache).u≈exact_sol[i](dim, nout, lb, ub) rtol=1e-2
+            @test solve!(cache).u ≈ exact_sol[i](dim, nout, lb, ub) rtol = 1.0e-2
             cache.ub = ub = 3.5
-            @test solve!(cache).u≈exact_sol[i](dim, nout, lb, ub) rtol=1e-2
+            @test solve!(cache).u ≈ exact_sol[i](dim, nout, lb, ub) rtol = 1.0e-2
             cache.p = Inf
-            @test solve!(cache).u≈exact_sol[i](dim, nout, lb, ub) rtol=1e-2
+            @test solve!(cache).u ≈ exact_sol[i](dim, nout, lb, ub) rtol = 1.0e-2
         end
     end
 end
@@ -401,10 +441,10 @@ end
 @testset "issue242" begin
     f242(x, p) = p / (x^2 + p^2)
     domain242 = (-1, 1)
-    p242 = 1e-3
-    for abstol in [1e-2, 1e-4, 1e-6, 1e-8]
+    p242 = 1.0e-3
+    for abstol in [1.0e-2, 1.0e-4, 1.0e-6, 1.0e-8]
         @test solve(IntegralProblem(f242, domain242, p242; abstol), QuadGKJL()).u ==
-              solve(IntegralProblem(f242, domain242, p242), QuadGKJL(); abstol).u
+            solve(IntegralProblem(f242, domain242, p242), QuadGKJL(); abstol).u
     end
 end
 
@@ -418,12 +458,12 @@ end
         sol_bf = solve(prob_bf, QuadGKJL())
         expected_bf = 1 - cos(BigFloat(1))
         @test sol_bf.u isa BigFloat
-        @test sol_bf.u≈expected_bf rtol=1e-10
+        @test sol_bf.u ≈ expected_bf rtol = 1.0e-10
 
         # Test HCubatureJL with BigFloat scalar bounds
         sol_hc_bf = solve(prob_bf, HCubatureJL())
         @test sol_hc_bf.u isa BigFloat
-        @test sol_hc_bf.u≈expected_bf rtol=1e-10
+        @test sol_hc_bf.u ≈ expected_bf rtol = 1.0e-10
 
         # Test HCubatureJL with BigFloat vector bounds
         f_bf_2d = (x, p) -> sin(x[1]) * cos(x[2])
@@ -469,7 +509,7 @@ end
         sol_quadgk_c = solve(prob_quadgk_c, QuadGKJL())
         expected_c = (exp(im) - 1) / im
         @test sol_quadgk_c.u isa Complex
-        @test sol_quadgk_c.u≈expected_c rtol=1e-8
+        @test sol_quadgk_c.u ≈ expected_c rtol = 1.0e-8
     end
 
     @testset "Float32 type preservation" begin

--- a/test/nested_ad_tests.jl
+++ b/test/nested_ad_tests.jl
@@ -5,13 +5,15 @@ my_function(x, p) = x^2 + p[1]^3 * x + p[2]^2
 function my_integration(p)
     my_problem = IntegralProblem(my_function, (-1.0, 1.0), p)
     # return solve(my_problem, HCubatureJL(), reltol=1e-3, abstol=1e-3)  # Works
-    return solve(my_problem, CubatureJLh(), reltol = 1e-3, abstol = 1e-3)  # Errors
+    return solve(my_problem, CubatureJLh(), reltol = 1.0e-3, abstol = 1.0e-3)  # Errors
 end
 my_solution = my_integration(my_parameters)
 @test ForwardDiff.jacobian(my_integration, my_parameters) ≈ [0.0 8.0]
 @test ForwardDiff.jacobian(x -> ForwardDiff.jacobian(my_integration, x), my_parameters) ≈
-      [0.0 0.0
-       0.0 4.0]
+    [
+    0.0 0.0
+    0.0 4.0
+]
 
 ff(x, p) = sum(sin.(x .* p))
 lb = ones(2)
@@ -20,12 +22,12 @@ p = [1.5, 2.0]
 
 function testf(p)
     prob = IntegralProblem(ff, (lb, ub), p)
-    sin(solve(prob, CubaCuhre(), reltol = 1e-6, abstol = 1e-6)[1])
+    return sin(solve(prob, CubaCuhre(), reltol = 1.0e-6, abstol = 1.0e-6)[1])
 end
 
 hp1 = FiniteDiff.finite_difference_hessian(testf, p)
 hp2 = ForwardDiff.hessian(testf, p)
-@test hp1≈hp2 atol=1e-4
+@test hp1 ≈ hp2 atol = 1.0e-4
 
 ff2(x, p) = x * p[1] .+ p[2] * p[3]
 lb = 1.0
@@ -36,7 +38,7 @@ prob = IntegralProblem(_ff3, (lb, ub), p)
 
 function testf3(lb, ub, p; f = _ff3)
     prob = IntegralProblem(_ff3, (lb, ub), p)
-    solve(prob, CubatureJLh(); reltol = 1e-3, abstol = 1e-3)[1]
+    return solve(prob, CubatureJLh(); reltol = 1.0e-3, abstol = 1.0e-3)[1]
 end
 
 dp1 = ForwardDiff.gradient(p -> testf3(lb, ub, p), p)

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -4,8 +4,10 @@ using Test
     Aqua.find_persistent_tasks_deps(Integrals)
     Aqua.test_ambiguities(Integrals, recursive = false)
     Aqua.test_deps_compat(Integrals)
-    Aqua.test_piracies(Integrals,
-        treat_as_own = [IntegralProblem, SampledIntegralProblem])
+    Aqua.test_piracies(
+        Integrals,
+        treat_as_own = [IntegralProblem, SampledIntegralProblem]
+    )
     Aqua.test_project_extras(Integrals)
     Aqua.test_stale_deps(Integrals)
     Aqua.test_unbound_args(Integrals)

--- a/test/quadrule_tests.jl
+++ b/test/quadrule_tests.jl
@@ -33,7 +33,7 @@ p = 2.0
 prob = IntegralProblem(f, (lb, ub), p)
 u = solve(prob, alg).u
 
-@test u≈exact_f(lb, ub, p) rtol=1e-3
+@test u ≈ exact_f(lb, ub, p) rtol = 1.0e-3
 
 # multi-dim
 
@@ -52,7 +52,7 @@ p = 1.2
 prob = IntegralProblem(f, (lb, ub), p)
 u = solve(prob, alg).u
 
-@test u≈exact_f(lb, ub, p) rtol=1e-3
+@test u ≈ exact_f(lb, ub, p) rtol = 1.0e-3
 
 # 1d with inf limits
 
@@ -66,7 +66,7 @@ p = 1.0
 
 prob = IntegralProblem(g, (lb, ub), p)
 
-@test solve(prob, alg).u≈pi rtol=1e-4
+@test solve(prob, alg).u ≈ pi rtol = 1.0e-4
 
 # 1d with nout
 
@@ -80,7 +80,7 @@ p = (1.0, 1.3)
 
 prob = IntegralProblem(g2, (lb, ub), p)
 
-@test solve(prob, alg).u≈[pi, pi] rtol=1e-4
+@test solve(prob, alg).u ≈ [pi, pi] rtol = 1.0e-4
 
 #= derivative tests
 


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)