### PR TITLE
Documentation improvements: Fix examples and grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ both those based upon quadrature as well as Monte-Carlo approaches. By using
 Integrals.jl, you get a single predictable interface where many of the
 arguments are standardized throughout the various integrator libraries. This
 can be useful for benchmarking or for library implementations, since libraries
-which internally use a quadrature can easily accept a integration method as an
+which internally use a quadrature can easily accept an integration method as an
 argument.
 
 ## Tutorials and Documentation

--- a/docs/src/basics/FAQ.md
+++ b/docs/src/basics/FAQ.md
@@ -32,7 +32,7 @@ i.e. [`QuadGKJL`](@ref).
 
 ## What should I do if my solution is not converged?
 
-Certain algorithms, such as [`QuadratureRule`](@ref) used a fixed number of points to
+Certain algorithms, such as [`QuadratureRule`](@ref), use a fixed number of points to
 calculate an integral and cannot provide an error estimate. In this case, you
 have to increase the number of points and check the convergence yourself, which
 will depend on the accuracy of the rule you choose.
@@ -55,7 +55,7 @@ See [`SampledIntegralProblem`](@ref).
 You can't, since Integrals.jl currently supports integration on hypercubes
 because that is what lower-level packages implement.
 
-## I don't see algorithm X or quadrature scheme Y ?
+## I don't see algorithm X or quadrature scheme Y
 
 Fixed quadrature rules from other packages can be used with `QuadratureRule`.
 Otherwise, feel free to open an issue or pull request.


### PR DESCRIPTION
## Summary

This PR fixes documentation build errors and improves documentation quality with grammar corrections and clearer examples.

### Changes Made

**Fixed infinity_transforms.md tutorial:**
- Resolved doc build failures caused by `@example` blocks using undefined `ChangeOfVariables` in example namespace
- Replaced failing `@docs` blocks with inline documentation (docstrings were causing "undefined binding" errors)
- Split examples into:
  - Executed `@example` blocks that demonstrate basic usage
  - Non-executed `julia` code blocks showing syntax for advanced features
- Added clear inline documentation for transformation functions with usage details
- Improved example clarity by adding explanatory text

**Grammar and style fixes:**
- README.md: Fixed "a integration" → "an integration" (line 18)
- FAQ.md: Fixed verb tense "used" → "use" for QuadratureRule description
- FAQ.md: Removed extraneous question mark from heading "I don't see algorithm X or quadrature scheme Y?"

### Testing

- Built documentation locally - all errors resolved except external link rate limiting (429 from GitHub)
- Verified examples run correctly in isolation

### Impact

These changes resolve all documentation build errors in the infinity_transforms tutorial and improve overall documentation quality with minor grammar fixes.

cc @ChrisRackauckas