### PR TITLE
Fix: check fast_scalar_indexing before using indexing fast path

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "4.8.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 HCubature = "19dc6840-f33b-545b-b366-655c7e3ffd49"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -37,6 +38,7 @@ IntegralsZygoteExt = ["Zygote", "ChainRulesCore", "Mooncake"]
 [compat]
 Aqua = "0.8"
 Arblib = "1"
+ArrayInterface = "7"
 ChainRulesCore = "1.18"
 CommonSolve = "0.2.4"
 Cuba = "2.2"

--- a/src/Integrals.jl
+++ b/src/Integrals.jl
@@ -10,6 +10,7 @@ using HCubature: HCubature, hcubature, hquadrature
 using SciMLBase: init, solve!
 using LinearAlgebra: LinearAlgebra, /, norm
 using Random: Random
+using ArrayInterface: ArrayInterface
 
 include("algorithms_meta.jl")
 include("common.jl")

--- a/src/sampled.jl
+++ b/src/sampled.jl
@@ -49,33 +49,43 @@ dimension(D::Int) = D
 
 # Specialized evalrule for 1D arrays (Vector) - returns scalar
 function evalrule(data::AbstractVector, weights, dim)
-    n = length(data)
-    n == 0 && throw(ArgumentError("No points to integrate"))
-    out = data[1] * weights[1]
-    @inbounds for i in 2:n
-        out += weights[i] * data[i]
+    # Only use fast indexing path when scalar indexing is efficient (e.g., not on GPU arrays)
+    if ArrayInterface.fast_scalar_indexing(data)
+        n = length(data)
+        n == 0 && throw(ArgumentError("No points to integrate"))
+        out = data[1] * weights[1]
+        @inbounds for i in 2:n
+            out += weights[i] * data[i]
+        end
+        return out
+    else
+        return _evalrule_general(data, weights, dim)
     end
-    return out
 end
 
 # Specialized evalrule for 2D arrays (Matrix) integrating over last dimension
 # This is the most common case for vector-valued integrands
 function evalrule(data::AbstractMatrix{T}, weights, dim) where {T}
-    m, n = size(data)
-    n == 0 && throw(ArgumentError("No points to integrate"))
-    if dim == 2 || dim == ndims(data)
-        # Integration over columns (last dimension) - the common case
-        out = zeros(T, m)
-        @inbounds for i in 1:n
-            w = weights[i]
-            @simd for j in 1:m
-                out[j] += w * data[j, i]
+    # Only use fast indexing path when scalar indexing is efficient (e.g., not on GPU arrays)
+    if ArrayInterface.fast_scalar_indexing(data)
+        m, n = size(data)
+        n == 0 && throw(ArgumentError("No points to integrate"))
+        if dim == 2 || dim == ndims(data)
+            # Integration over columns (last dimension) - the common case
+            out = zeros(T, m)
+            @inbounds for i in 1:n
+                w = weights[i]
+                @simd for j in 1:m
+                    out[j] += w * data[j, i]
+                end
             end
+            return out
+        else
+            # Integration over rows (dim=1) - less common
+            # Fall back to general implementation
+            return _evalrule_general(data, weights, dim)
         end
-        return out
     else
-        # Integration over rows (dim=1) - less common
-        # Fall back to general implementation
         return _evalrule_general(data, weights, dim)
     end
 end


### PR DESCRIPTION
## Summary

- Add `ArrayInterface.fast_scalar_indexing(data)` check to the specialized `evalrule` methods for `AbstractVector` and `AbstractMatrix`
- Fall back to the general `_evalrule_general` implementation when scalar indexing is not fast (e.g., GPU arrays)

This is a follow-up to PR #292 to ensure the performance optimizations are GPU-compatible.

## Changes

- Added ArrayInterface as a dependency
- Modified `evalrule(data::AbstractVector, ...)` to check `fast_scalar_indexing` before using the indexing fast path
- Modified `evalrule(data::AbstractMatrix, ...)` to check `fast_scalar_indexing` before using the indexing fast path

## Test plan

- [x] All existing tests pass locally (Sampled Integration Tests: 29/29)
- [x] Interface Tests: 851/851
- [x] Quality Assurance: 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)