### PR TITLE
Relax Zygote compat to allow 0.6.69+ and 0.7.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -66,7 +66,7 @@ SafeTestsets = "0.1"
 SciMLBase = "2.104"
 StaticArrays = "1"
 Test = "1.10"
-Zygote = "0.7.10"
+Zygote = "0.6.69, 0.7"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
## Summary

Relaxes the Zygote compat from `"0.7.10"` (strict) back to `"0.6.69, 0.7"` (which was the compat in v4.6.1).

## Problem

The strict `Zygote = "0.7.10"` compat is causing issues with downstream packages like NeuralPDE.jl. When NeuralPDE resolves packages, it gets Integrals ≥4.7.0 which forces Zygote 0.7.10, which then triggers a bug in Julia's `Base.Meta.partially_inline!` function.

### Root Cause

There's a typo bug in Julia's `base/meta.jl` (introduced in commit `b845695e` from June 2018) where line 412 references `spvals` instead of `static_param_values`:

```julia
# Line 412 - BUG: spvals is undefined
@assert !isa(type_signature, UnionAll) || !isempty(spvals)

# Compare to line 421 - Correct:  
@assert !isa(type_signature, UnionAll) || !isempty(static_param_values)
```

This bug gets triggered when Zygote/IRTools calls `Base.Meta.partially_inline!` on code containing `@cfunction` with type parameters (like Cubature.jl's `integrands(d::D, ...) where {D}` function).

### Why This Helps

By relaxing the Zygote compat, downstream packages can potentially resolve to older Zygote versions that may use different code paths that don't trigger the Julia bug. Even if it doesn't fully fix the issue, it gives more flexibility for workarounds.

## Test plan

- [ ] CI passes
- [ ] Downstream packages (NeuralPDE.jl) can resolve with broader Zygote versions

🤖 Generated with [Claude Code](https://claude.ai/code)