### PR TITLE
Migrate CI to centralized SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,6 @@ on:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -33,30 +32,8 @@ jobs:
           # nopre tests (JET) should not run on pre-release or LTS Julia versions
           - group: nopre
             version: 'pre'
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-      - uses: actions/cache@v5
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        env:
-          GROUP: ${{ matrix.group }}
-      - uses: julia-actions/julia-processcoverage@v1
-        with:
-          directories: src,ext
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      julia-version: "${{ matrix.version }}"
+      group: "${{ matrix.group }}"
+    secrets: "inherit"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -10,24 +10,8 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: 'lts'
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: Build and deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-        run: julia --project=docs/ --code-coverage=user docs/make.jl
-      - uses: julia-actions/julia-processcoverage@v1
-        with:
-          directories: src
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    with:
+      coverage: true
+      coverage-directories: "src"
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,25 +12,16 @@ on:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         group:
           - Core
-        downgrade_mode: ['alldeps']
         julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-#        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
-        env:
-          GROUP: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "${{ matrix.julia-version }}"
+      group: "${{ matrix.group }}"
+      skip: "Pkg,TOML"
+      projects: "."
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -10,12 +10,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0 
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Migrates this repository's GitHub Actions onto the centralized reusable workflows in `SciML/.github`, pinned to `@v1`. Behavior (triggers, matrices, coverage) is preserved.

## Workflows converted
- **CI.yml** → caller of `tests.yml@v1`. Reproduces the full `group` (Core/AD/nopre) × `version` (1/lts/pre) matrix, including all `exclude:` entries. Coverage left at the default (`src,ext`), matching the original codecov collection.
- **Documentation.yml** → caller of `documentation.yml@v1` with `coverage: true` and `coverage-directories: src` (the original used `--code-coverage=user` and processed only `src`).
- **Downgrade.yml** → caller of `downgrade.yml@v1`, preserving `group=Core`, `julia-version=1.10`, `skip=Pkg,TOML`, `projects=.`, and `allow-reresolve=false` (was `ALLOW_RERESOLVE: false`).
- **FormatCheck.yml** → caller of `runic.yml@v1` (replaces the `fredrikekre/runic-action` steps).
- **SpellCheck.yml** → caller of `spellcheck.yml@v1` (replaces the `crate-ci/typos` step).

## Workflows unchanged
- **TagBot.yml** — left as-is.

## Added / removed
- No `CompatHelper.yml` exists in this repo, so none was removed and no Julia dependabot block needed to be added for that reason.

## dependabot.yml changes
- Removed the `crate-ci/typos` `ignore` block (typos version is now pinned inside the centralized `spellcheck` workflow).
- Preserved the existing `julia` block (`/`, `/docs`, `/test`) unchanged.
- Preserved the existing `github-actions` block (`directory: /`, weekly).

## Branch protection warning
The job/check names change with this migration (the work now runs inside the reusable workflows). Any branch-protection **required status checks** referencing the old job names will need to be updated to the new check names once these workflows run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)