### PR TITLE
Raise Mooncake compat floor to 0.5.36 (fix Downgrade resolution)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Integrals"
 uuid = "de52edbc-65ea-441a-8357-d3a637375a31"
-version = "5.4.2"
+version = "5.4.3"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -62,7 +62,7 @@ HCubature = "1.7"
 LinearAlgebra = "1.10"
 MCIntegration = "0.4.2"
 MonteCarloIntegration = "0.2"
-Mooncake = "0.5.6"
+Mooncake = "0.5.36"
 QuadGK = "2.11"
 Random = "1.10"
 Reexport = "1.2"


### PR DESCRIPTION
## What

Raise the `Mooncake` `[compat]` floor from `0.5.6` to the latest registered Mooncake (`0.5.36`) in the root `Project.toml` — the only Project.toml in the repo that declares a Mooncake compat entry.

## Why

The old floor (`0.5.6`) let the Downgrade CI min-resolution pin an ancient Mooncake, which fed the Resolver.jl-capacity `Unsatisfiable` wall. Limiting to the latest Mooncake stops the downgrade from selecting an old version.

## Raised floors

| File | Old floor | New floor |
|------|-----------|-----------|
| `Project.toml` | `0.5.6` | `0.5.36` |

Also bumped the package version `5.4.2` -> `5.4.3` (compat narrowing = patch-level change).

## Verification (resolves_at_min = true)

Reproduced the downgrade min-resolution on **Julia 1.12.6** using `julia-actions/julia-downgrade-compat`'s `downgrade.jl` (`mode=alldeps`, the same merged `[extras]`+`[targets].test` path CI uses). Result:

```
[ Info: Running resolver on merged project (extras) for . with --min=@alldeps
[ Info: Successfully resolved minimal versions for . (with extras)
```

- Resolution **SUCCEEDS** — no `Unsatisfiable`, exit code 0.
- Mooncake resolved to exactly `0.5.36` in the manifest (the new floor).

So the floor-raise alone fixes the Downgrade Unsatisfiable wall for this repo; the Resolver-capacity blocker (#52) is not hit here.

---

Please ignore until reviewed by @ChrisRackauckas.