### PR TITLE
Fix sampled matrix integration over dimensional axes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -71,6 +71,7 @@ SciMLLogging = "1.10.1, 2"
 SciMLTesting = "1"
 StaticArrays = "1.9.8"
 Test = "1.10"
+Unitful = "1"
 Zygote = "0.7.10"
 julia = "1.10"
 
@@ -90,6 +91,7 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["ADTypes", "Arblib", "StaticArrays", "SafeTestsets", "SciMLTesting", "Test", "Distributions", "ChainRulesCore", "FastGaussQuadrature", "FastTanhSinhQuadrature", "Cuba", "Cubature", "MCIntegration", "DifferentiationInterface", "HAdaptiveIntegration"]
+test = ["ADTypes", "Arblib", "StaticArrays", "SafeTestsets", "SciMLTesting", "Test", "Distributions", "ChainRulesCore", "FastGaussQuadrature", "FastTanhSinhQuadrature", "Cuba", "Cubature", "MCIntegration", "DifferentiationInterface", "HAdaptiveIntegration", "Unitful"]

--- a/src/sampled.jl
+++ b/src/sampled.jl
@@ -72,8 +72,12 @@ function evalrule(data::AbstractMatrix{T}, weights, dim) where {T}
         n == 0 && throw(ArgumentError("No points to integrate"))
         if dim == 2 || dim == ndims(data)
             # Integration over columns (last dimension) - the common case
-            out = zeros(T, m)
-            @inbounds for i in 1:n
+            w1 = weights[1]
+            out = Vector{Base.promote_op(*, typeof(w1), T)}(undef, m)
+            @inbounds @simd for j in 1:m
+                out[j] = w1 * data[j, 1]
+            end
+            @inbounds for i in 2:n
                 w = weights[i]
                 @simd for j in 1:m
                     out[j] += w * data[j, i]

--- a/src/sampled.jl
+++ b/src/sampled.jl
@@ -73,7 +73,8 @@ function evalrule(data::AbstractMatrix{T}, weights, dim) where {T}
         if dim == 2 || dim == ndims(data)
             # Integration over columns (last dimension) - the common case
             w1 = weights[1]
-            out = Vector{Base.promote_op(*, typeof(w1), T)}(undef, m)
+            out_type = m == 0 ? typeof(w1 * zero(T)) : typeof(w1 * data[1, 1])
+            out = Vector{out_type}(undef, m)
             @inbounds @simd for j in 1:m
                 out[j] = w1 * data[j, 1]
             end

--- a/test/sampled_tests.jl
+++ b/test/sampled_tests.jl
@@ -1,4 +1,4 @@
-using Integrals, Test
+using Integrals, Test, Unitful
 @testset "Sampled Integration" begin
     lb = 0.4
     ub = 1.1
@@ -30,6 +30,16 @@ using Integrals, Test
             end
         end
     end
+end
+
+@testset "Sampled integration with dimensional axes" begin
+    data = ones(2, 3)
+    axis = [0.0, 1.0, 2.0]u"m"
+
+    prob = SampledIntegralProblem(data, axis; dim = 2)
+    sol = solve(prob, TrapezoidalRule())
+
+    @test sol.u == [2.0, 2.0]u"m"
 end
 
 @testset "Caching interface" begin


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Fix the sampled matrix fast path to allocate its accumulator using the `weight * sample` result type instead of `eltype(data)`.
- Add a Unitful regression test for `SampledIntegralProblem(data, axis; dim = 2)` with a dimensional axis.
- Add Unitful as a test-only dependency through the main package test target.

Fixes #341.

## Tests

- Reproduced the original failure on the unmodified branch with Julia 1.12.6: `DimensionError: 0.0 and 0.5 m are not dimensionally compatible` at `src/sampled.jl:79`.
- `GROUP=Core timeout 3600 /home/crackauc/.juliaup/bin/julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`
  - `Core/sampled_tests.jl`: 30 passed
  - `Core/interface_tests.jl`: 871 passed
  - `Core/inf_integral_tests.jl`: 746 passed
  - overall: `Testing Integrals tests passed`
- `GROUP=AD timeout 7200 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`
  - `AD/derivative_tests.jl`: 2005 passed, 1176 broken
  - `AD/nested_ad_tests.jl`: 6 passed
  - overall: `Testing Integrals tests passed`
- `Runic v1.7.0`: `/home/crackauc/.juliaup/bin/julia +1.12 --project=.runic -e 'using Runic; exit(Runic.main(ARGS))' -- --check .`
