### PR TITLE
Bump version to 5.4.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Integrals"
 uuid = "de52edbc-65ea-441a-8357-d3a637375a31"
-version = "5.4.2"
+version = "5.4.3"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (5.4.2 -> 5.4.3) to release unreleased commits on `master` via JuliaRegistrator.