### PR TITLE
Release prep: bump Integrals to 5.4.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Integrals"
 uuid = "de52edbc-65ea-441a-8357-d3a637375a31"
-version = "5.4.3"
+version = "5.4.4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Patch release for accumulated docstring/QA/test-scaffolding changes since 5.4.3; version-only bump.