### PR TITLE
Use default rendered API docs QA

### DIFF
--- a/docs/src/basics/solve.md
+++ b/docs/src/basics/solve.md
@@ -13,5 +13,4 @@ solve!(cache::Integrals.IntegralCache)
 solve!(cache::Integrals.SampledIntegralCache)
 isinplace(cache::Integrals.IntegralCache)
 ReturnCode
-remake
 ```

--- a/docs/src/basics/solve.md
+++ b/docs/src/basics/solve.md
@@ -13,4 +13,5 @@ solve!(cache::Integrals.IntegralCache)
 solve!(cache::Integrals.SampledIntegralCache)
 isinplace(cache::Integrals.IntegralCache)
 ReturnCode
+remake
 ```

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,7 +3,6 @@ using JET
 
 run_qa(
     Integrals;
-    explicit_imports = true,
     aqua_kwargs = (;
         # IntegralProblem / SampledIntegralProblem are SciMLBase types this package
         # owns the integral-solver methods for, so dispatching on them is not piracy.

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,12 +1,9 @@
 using SciMLTesting, Integrals, Test
 using JET
 
-const UPSTREAM_RENDERED_API = (:SciMLBase, :remake)
-
 run_qa(
     Integrals;
     explicit_imports = true,
-    api_docs_kwargs = (; rendered = true, rendered_ignore = UPSTREAM_RENDERED_API),
     aqua_kwargs = (;
         # IntegralProblem / SampledIntegralProblem are SciMLBase types this package
         # owns the integral-solver methods for, so dispatching on them is not piracy.


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

Removes the repository-specific rendered-docs override and documents the public `remake` re-export in the existing interface utilities page. This depends on SciMLTesting#26 for the inherited module re-export rule.