### PR TITLE
Sync package versions with the General registry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Integrals"
 uuid = "de52edbc-65ea-441a-8357-d3a637375a31"
-version = "5.4.4"
+version = "5.4.5"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What this changes

| package | from | to | why |
|---|---|---|---|
| `Integrals` | 5.4.4 | 5.4.5 | unreleased changes with no version bump |


## Why

Each `to` is the next sequential version after what is currently registered in
General. Versions that skip an unregistered version are rejected by AutoMerge's
sequential version number guideline, so they can never be registered as-is;
packages with unreleased changes and no bump cannot be registered at all.

Only the top-level `version` field of each `Project.toml` is touched.

After merge, each package still needs `@JuliaRegistrator register` (with
`subdir=` where applicable).